### PR TITLE
Improve names edit handling (fixes #123) (fixes #149)

### DIFF
--- a/lang/bg.json
+++ b/lang/bg.json
@@ -28,7 +28,7 @@
     "Year": "Година",
     "Not authorized": "Неоторизиран",
     "Blog": "Блог",
-    "Switch to custom type": "Преминете към потребителски тип",
+    "Add custom type": "Преминете към потребителски тип",
     "Please confirm your e-mail address by clicking the link in the e-mail you received and then wait for the tree owner to activate your account.": "Моля, потвърдете своя имейл адрес, като щракнете върху връзката в имейла, който сте получили, и след това изчакайте собственикът на дървото да активира вашия акаунт.",
     "Select at least one object type": "Изберете поне един тип обект",
     "Edit coordinates": "Редактиране на координати",

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -4,7 +4,7 @@
     "Manage users": "Gestionar usuaris",
     "Global": "Global",
     "Please upload a file in Gramps XML (.gramps) format without media files.": "Penja un fitxer en format Gramps XML (.gramps) sense fitxers multimèdia.",
-    "Switch to custom type": "Canviar al tipus personalitzat",
+    "Add custom type": "Afegeix un tipus personalitzat",
     "Switch to default type": "Canviar al tipus predeterminat",
     "Custom type": "Tipus personalitzat",
     "A new version of the app is available.": "Hi ha disponible una nova versió de l'aplicació.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -59,7 +59,7 @@
     "Select at least one object type": "Výběr alespoň jednoho typu objektu",
     "filter": "filtrovat",
     "Properties": "Vlastnosti",
-    "Switch to custom type": "Přepnout na vlastní typ",
+    "Add custom type": "Přepnout na vlastní typ",
     "Switch to default type": "Přepnout na výchozí typ",
     "Custom type": "Vlastní typ",
     "unconfirmed": "nepotvrzené",

--- a/lang/da.json
+++ b/lang/da.json
@@ -5,7 +5,7 @@
     "login": "login",
     "Lost password?": "Glemt kodeord?",
     "Register new account": "Registrer ny konto",
-    "Switch to custom type": "Skift til tilpasset type",
+    "Add custom type": "Skift til tilpasset type",
     "Switch to default type": "Skift til standardtype",
     "Custom type": "Tilpasseet type",
     "Blog": "Blog",

--- a/lang/de.json
+++ b/lang/de.json
@@ -15,6 +15,7 @@
     "Recently changed objects": "Zuletzt geänderte Objekte",
     "Select language": "Sprache auswählen",
     "Show in tree": "Im Baum anzeigen",
+    "Show more": "Mehr anzeigen",
     "User settings": "Benutzereinstellungen",
     "Anniversaries": "Jahrestage",
     "Export": "Exportieren",

--- a/lang/de.json
+++ b/lang/de.json
@@ -68,7 +68,7 @@
     "unconfirmed": "unbestätigt",
     "Switch to default type": "Zu Standardart wechseln",
     "Custom type": "Benutzerdefinierte Art",
-    "Switch to custom type": "Zu benutzerdefinierter Art wechseln",
+    "Add custom type": "Benutzerdefinierte Art hinzufügen",
     "Replace file": "Datei ersetzen",
     "Year": "Jahr",
     "Month": "Monat",

--- a/lang/de_AT.json
+++ b/lang/de_AT.json
@@ -129,6 +129,7 @@
     "Task": "Aufgabe",
     "New Task": "Neue Aufgabe",
     "Show in blog": "Im Blog anzeigen",
+    "Show more": "Mehr anzeigen",
     "Set Priority": "Priorität festlegen",
     "Set Status": "Status festlegen",
     "Done": "Erledigt",

--- a/lang/de_AT.json
+++ b/lang/de_AT.json
@@ -85,7 +85,7 @@
     "Update search index": "Suchindex aktualisieren",
     "Manually updating the search index is usually unnecessary, but it may become necessary after an upgrade.": "Eine manuelle Aktualisierung des Suchindexes ist in der Regel nicht erforderlich, kann aber nach einem Upgrade notwendig werden.",
     "Event Year": "Ereignisjahr",
-    "Switch to custom type": "Wechseln zu benutzerdefinierter Art",
+    "Add custom type": "Benutzerdefinierte Art hinzufügen",
     "Switch to default type": "Wechseln zu Standard-Art",
     "Custom type": "Benutzerdefinierte Art",
     "New account registered successfully.": "Neues Konto erfolgreich registriert.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -167,5 +167,8 @@
   "Delete Tag": "Delete Tag",
   "Edit Tag": "Edit Tag",
   "Revision History": "Revision History",
-  "simple": "simple"
+  "simple": "simple",
+  "Are you sure?": "Are you sure?",
+  "This action cannot be undone.": "This action cannot be undone.",
+  "Yes": "Yes"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,7 +66,7 @@
   "Contributor": "Contributor",
   "Editor": "Editor",
   "Owner": "Owner",
-  "Switch to custom type": "Switch to custom type",
+  "Add custom type": "Add custom type",
   "Switch to default type": "Switch to default type",
   "Custom type": "Custom type",
   "Replace file": "Replace file",

--- a/lang/en.json
+++ b/lang/en.json
@@ -113,6 +113,7 @@
   "Tasks": "Tasks",
   "New Task": "New Task",
   "Show in blog": "Show in blog",
+  "Show more": "Show more",
   "Set Priority": "Set Priority",
   "Set Status": "Set Status",
   "Done": "Done",

--- a/lang/en_GB.json
+++ b/lang/en_GB.json
@@ -66,7 +66,7 @@
     "Contributor": "Contributor",
     "Editor": "Editor",
     "Owner": "Owner",
-    "Switch to custom type": "Switch to custom type",
+    "Add custom type": "Add custom type",
     "Switch to default type": "Switch to default type",
     "Custom type": "Custom type",
     "Replace file": "Replace file",

--- a/lang/en_GB.json
+++ b/lang/en_GB.json
@@ -15,6 +15,7 @@
     "Recently changed objects": "Recently changed objects",
     "Select language": "Select language",
     "Show in tree": "Show in tree",
+    "Show more": "Show more",
     "User settings": "User settings",
     "Anniversaries": "Anniversaries",
     "Export": "Export",

--- a/lang/es.json
+++ b/lang/es.json
@@ -8,7 +8,7 @@
     "To start using the blog, add a source with tag 'Blog'.": "Para empezar a utilizar el blog, añada una fuente con la etiqueta 'Blog'.",
     "Optionally, enter existing IMAP credentials to enable e-mail notifications required e.g. for user registration.": "Opcionalmente, introduzca las credenciales IMAP existentes para habilitar las notificaciones por correo electrónico necesarias, por ejemplo, para el registro de usuarios.",
     "SMTP user": "Usuario SMTP",
-    "Switch to custom type": "Cambiar a un tipo personalizado",
+    "Add custom typee": "Añadir un tipo personalizado",
     "Switch to default type": "Cambiar al tipo por defecto",
     "Custom type": "Tipo personalizado",
     "Blog": "Blog",

--- a/lang/fi.json
+++ b/lang/fi.json
@@ -59,7 +59,7 @@
     "Place Hierarchy": "Paikkahierarkia",
     "If you intend to synchronize an existing Gramps database with Gramps Web, use the Gramps XML (.gramps) format instead.": "Jos aiot synkronisoida olemassaolevan Gramps-tietokannan Gramps Webiin, käytä Gramps XML (.gramps) -muotoa tämän sijaan.",
     "Owner": "Omistaja",
-    "Switch to custom type": "Vaihda mukautettuun tyyppiin",
+    "Add custom type": "Vaihda mukautettuun tyyppiin",
     "Switch to default type": "Vaihda oletustyyppiin",
     "Custom type": "Mukautettu",
     "Global": "Globaali",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -61,7 +61,7 @@
     "Properties": "Propriétés",
     "Update search index": "Mettre à jour l'index de recherche",
     "Manually updating the search index is usually unnecessary, but it may become necessary after an upgrade.": "La mise à jour manuelle de l'index de recherche est généralement inutile, mais cela peut devenir nécessaire après une mise à niveau.",
-    "Switch to custom type": "Changer pour un type personnalisé",
+    "Add custom type": "Ajouter un type personnalisé",
     "Switch to default type": "Changer pour un type par défaut",
     "Year": "Année",
     "Month": "Mois",

--- a/lang/he.json
+++ b/lang/he.json
@@ -57,7 +57,7 @@
     "Username": "שם משתמש",
     "All": "הכול",
     "Select at least one object type": "נא לבחור לפחות סוג עצם אחד",
-    "Switch to custom type": "החלפה לסוג מותאם אישית",
+    "Add custom type": "החלפה לסוג מותאם אישית",
     "Switch to default type": "החלפה לסוג ברירת מחדל",
     "Custom type": "סוג מותאם אישית",
     "filter": "מסנן",

--- a/lang/hr.json
+++ b/lang/hr.json
@@ -66,7 +66,7 @@
     "Contributor": "Doprinositelj",
     "Editor": "Urednik",
     "Owner": "Vlasnik",
-    "Switch to custom type": "Promijeni na prilagođenu vrstu",
+    "Add custom type": "Promijeni na prilagođenu vrstu",
     "Switch to default type": "Promijeni na zadanu vrstu",
     "Custom type": "Prilagođena vrsta",
     "Replace file": "Zamijeni datoteku",

--- a/lang/it.json
+++ b/lang/it.json
@@ -65,7 +65,7 @@
     "Contributor": "Collaboratore",
     "Member": "Membro",
     "Owner": "Proprietario",
-    "Switch to custom type": "Passa a tipo personalizzato",
+    "Add custom type": "Aggiungi un tipo personalizzato",
     "Custom type": "Tipo personalizzato",
     "Switch to default type": "Passa a tipo predefinito",
     "unconfirmed": "non confermato",

--- a/lang/nb.json
+++ b/lang/nb.json
@@ -58,7 +58,7 @@
     "Register new account": "Registrer ny konto",
     "Password": "Passord",
     "Select at least one object type": "Velg minst én objekttype",
-    "Switch to custom type": "Bytt til egendefinert type",
+    "Add custom type": "Bytt til egendefinert type",
     "Switch to default type": "Bytt til forvalgt type",
     "Custom type": "Egendefinert type",
     "All": "Alle",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -59,7 +59,7 @@
     "Select at least one object type": "Selecteer ten minste één objecttype",
     "Properties": "Eigenschappen",
     "filter": "filteren",
-    "Switch to custom type": "Schakelen naar aangepast type",
+    "Add custom type": "Een aangepast type toevoegen",
     "Switch to default type": "Schakelen naar standaardtype",
     "Custom type": "Aangepast type",
     "unconfirmed": "onbevestigd",

--- a/lang/nn.json
+++ b/lang/nn.json
@@ -2,7 +2,7 @@
     "A new version of the app is available.": "Ein ny versjon av appen er tilgjengeleg.",
     "Blog": "Blogg",
     "Change E-mail": "Byte epostadresse",
-    "Switch to custom type": "Byt til tilpassa type",
+    "Add custom type": "Byt til tilpassa type",
     "Switch to default type": "Byt til standardtype",
     "Custom type": "Tilpassa type",
     "Change password": "Endre passord",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -55,7 +55,7 @@
     "Register new account": "Zarejestruj nowe konto",
     "Select at least one object type": "Wybierz co najmniej jeden typ objektu",
     "All": "Wszystkie",
-    "Switch to custom type": "Przełącz na typ niestandardowy",
+    "Add custom type": "Przełącz na typ niestandardowy",
     "Switch to default type": "Przełącz na typ domyślny",
     "Custom type": "Typ niestandardowy",
     "Place Hierarchy": "Hierarchia miejsc",

--- a/lang/pt_PT.json
+++ b/lang/pt_PT.json
@@ -66,7 +66,7 @@
     "Guest": "Convidado",
     "Member": "Membro",
     "Editor": "Editor",
-    "Switch to custom type": "Mudar para tipo personalizado",
+    "Add custom type": "Adicionar tipo personalizado",
     "Custom type": "Tipo personalizado",
     "Switch to default type": "Mudar para tipo pré-definido",
     "Replace file": "Substituir ficheiro",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -59,7 +59,7 @@
     "Select at least one object type": "Выберите хотя бы один тип объекта",
     "filter": "фильтр",
     "Properties": "Свойства",
-    "Switch to custom type": "Переключить на пользовательский тип",
+    "Add custom type": "Переключить на пользовательский тип",
     "Switch to default type": "Переключить на тип по умолчанию",
     "Custom type": "Пользовательский тип",
     "unconfirmed": "неподтверждено",

--- a/lang/sk.json
+++ b/lang/sk.json
@@ -60,7 +60,7 @@
     "Properties": "Vlastnosti",
     "filter": "filtrovať",
     "Switch to default type": "Prepnúť na štandardný typ",
-    "Switch to custom type": "Prepnúť na prispôsobený typ",
+    "Add custom type": "Prepnúť na prispôsobený typ",
     "Custom type": "Prispôsobený typ",
     "Owner": "Majiteľ",
     "Editor": "Editor",

--- a/lang/sr.json
+++ b/lang/sr.json
@@ -1,5 +1,5 @@
 {
-    "Switch to custom type": "Пребаци на прилагођени тип",
+    "Add custom type": "Пребаци на прилагођени тип",
     "Switch to default type": "Пребаци на подразумевани тип",
     "Custom type": "Прилагођени тип",
     "A new version of the app is available.": "Доступна је нова верзија апликације.",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -67,7 +67,7 @@
     "Contributor": "Bidragsgivare",
     "Editor": "Redaktör",
     "Owner": "Ägare",
-    "Switch to custom type": "Byt till anpassad typ",
+    "Add custom type": "Byt till anpassad typ",
     "Switch to default type": "Byt till standardtyp",
     "Custom type": "Anpassad typ",
     "Replace file": "Byt ut fil",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -59,7 +59,7 @@
     "From address": "Adresten",
     "filter": "süzgeç",
     "Properties": "Özellikler",
-    "Switch to custom type": "Özel türe geç",
+    "Add custom type": "Özel türe geç",
     "Switch to default type": "Varsayılan türe geç",
     "Custom type": "Özel tür",
     "unconfirmed": "doğrulanmamış",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -66,7 +66,7 @@
     "unconfirmed": "не підтверджено",
     "Owner": "Власник",
     "disabled": "вимкнено",
-    "Switch to custom type": "Перехід на користувацький тип",
+    "Add custom type": "Перехід на користувацький тип",
     "Switch to default type": "Перехід на типовий тип",
     "Custom type": "Користувацький тип",
     "Replace file": "Замінити файл",

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -1,5 +1,5 @@
 {
-    "Switch to custom type": "切换到自定义类型",
+    "Add custom type": "切换到自定义类型",
     "Switch to default type": "切换到默认类型",
     "Custom type": "自定义类型",
     "A new version of the app is available.": "应用存在可用新版本。",

--- a/src/components/GrampsjsEditableList.js
+++ b/src/components/GrampsjsEditableList.js
@@ -17,7 +17,7 @@ export class GrampsjsEditableList extends GrampsjsTranslateMixin(LitElement) {
       css`
         mwc-list,
         mwc-list > * {
-          --mdc-ripple-color: tranparent;
+          --mdc-ripple-color: transparent;
         }
 
         mwc-list > * {

--- a/src/components/GrampsjsFormEditName.js
+++ b/src/components/GrampsjsFormEditName.js
@@ -10,6 +10,17 @@ import './GrampsjsFormSelectType.js'
 import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 
 class GrampsjsFormEditName extends GrampsjsObjectForm {
+  static get properties() {
+    return {
+      isFormValid: {type: Boolean},
+    }
+  }
+
+  constructor() {
+    super()
+    this.isFormValid = false
+  }
+
   renderForm() {
     return html`
       <grampsjs-form-select-type
@@ -21,7 +32,7 @@ class GrampsjsFormEditName extends GrampsjsObjectForm {
         typeName="name_types"
         ?loadingTypes=${this.loadingTypes}
         defaultTypeName="Birth Name"
-        initialValue=${this.data?.type?.string || this.data?.type || ''}
+        initialValue=${this.data?.type?.string || this.data?.type || null}
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
         @formdata:changed="${this._handleFormData}"
@@ -41,6 +52,22 @@ class GrampsjsFormEditName extends GrampsjsObjectForm {
       >
       </grampsjs-form-name>
     `
+  }
+
+  _handleFormData(e) {
+    super._handleFormData(e)
+    this.checkFormValidity()
+  }
+
+  checkFormValidity() {
+    const selectType = this.shadowRoot.querySelector(
+      'grampsjs-form-select-type'
+    )
+    this.isFormValid = selectType === null ? true : selectType.isValid()
+  }
+
+  get isValid() {
+    return this.isFormValid
   }
 }
 

--- a/src/components/GrampsjsFormEditName.js
+++ b/src/components/GrampsjsFormEditName.js
@@ -41,7 +41,6 @@ class GrampsjsFormEditName extends GrampsjsObjectForm {
 
       <grampsjs-form-name
         origintype
-        showMore
         id="name"
         @formdata:changed="${this._handleFormData}"
         ?loadingTypes=${this.loadingTypes}

--- a/src/components/GrampsjsFormEditName.js
+++ b/src/components/GrampsjsFormEditName.js
@@ -21,7 +21,7 @@ class GrampsjsFormEditName extends GrampsjsObjectForm {
         typeName="name_types"
         ?loadingTypes=${this.loadingTypes}
         defaultTypeName="Birth Name"
-        initialValue=${this.data?.type || ''}
+        initialValue=${this.data?.type?.string || this.data?.type || ''}
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
         @formdata:changed="${this._handleFormData}"

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -180,7 +180,7 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
               icon="more_horiz"
             ></mwc-icon-button>
             <grampsjs-tooltip for="button-show-more" .strings="${this.strings}"
-              >${this._('Show Details')}</grampsjs-tooltip
+              >${this._('Show more')}</grampsjs-tooltip
             >
           `}
     `

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -166,7 +166,6 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
       <p class="${classMap({hide: !this.showMore})}">
         <mwc-icon-button
           @click="${this._handleAddSurname}"
-          class="edit"
           icon="add"
         ></mwc-icon-button>
       </p>

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -153,9 +153,13 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
         ? ''
         : html`
             <mwc-icon-button
+              id="button-show-more"
               @click="${this._handleShowMore}"
               icon="more_horiz"
             ></mwc-icon-button>
+            <grampsjs-tooltip for="button-show-more" .strings="${this.strings}"
+              >${this._('Show more')}</grampsjs-tooltip
+            >
           `}
     `
   }

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -122,9 +122,31 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
       <h4 class="label ${classMap({hide: !this.showMore})}">
         ${this._('Surnames')}
       </h4>
-
       ${(this.data.surname_list || [{}]).map(
-        (obj, i, arr) => html`
+        (obj, i) => html`
+          <mwc-icon-button
+            ?disabled="${!this.data?.surname_list ||
+            this.data?.surname_list?.length === 1}"
+            class="edit"
+            icon="delete"
+            @click="${() => this._handleDeleteSurname(i)}"
+          ></mwc-icon-button>
+
+          <mwc-icon-button
+            ?disabled="${!this.data?.surname_list || i === 0}"
+            class="edit"
+            icon="arrow_upward"
+            @click="${() => this._handleUpSurname(i)}"
+          ></mwc-icon-button>
+
+          <mwc-icon-button
+            ?disabled="${!this.data?.surname_list ||
+            i === this.data?.surname_list?.length - 1}"
+            class="edit"
+            icon="arrow_downward"
+            @click="${() => this._handleDownSurname(i)}"
+          ></mwc-icon-button>
+
           <grampsjs-form-surname
             ?origintype="${this.origintype}"
             ?showMore="${this.showMore}"
@@ -138,13 +160,13 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
             .typesLocale="${this.typesLocale}"
           >
           </grampsjs-form-surname>
-
-          ${i < arr.length - 1 ? html`<hr />` : ''}
+          <hr />
         `
       )}
       <p class="${classMap({hide: !this.showMore})}">
         <mwc-icon-button
           @click="${this._handleAddSurname}"
+          class="edit"
           icon="add"
         ></mwc-icon-button>
       </p>
@@ -153,6 +175,7 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
         ? ''
         : html`
             <mwc-icon-button
+              class="edit"
               id="button-show-more"
               @click="${this._handleShowMore}"
               icon="more_horiz"
@@ -188,6 +211,28 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
     }
   }
 
+  _handleDeleteSurname(i) {
+    this.data.surname_list.splice(i, 1)
+    this.data = {
+      ...this.data,
+      surname_list: [...this.data.surname_list],
+    }
+  }
+
+  _handleUpSurname(i) {
+    this.data = {
+      ...this.data,
+      surname_list: [...this.moveItem(this.data.surname_list, i, i - 1)],
+    }
+  }
+
+  _handleDownSurname(i) {
+    this.data = {
+      ...this.data,
+      surname_list: [...this.moveItem(this.data.surname_list, i, i + 1)],
+    }
+  }
+
   _handleFormData(e) {
     const originalTarget = e.composedPath()[0]
     if (
@@ -210,6 +255,13 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
     }
     e.stopPropagation()
     this.handleChange()
+  }
+
+  moveItem = (array, from, to) => {
+    const item = array[from]
+    array.splice(from, 1)
+    array.splice(to, 0, item)
+    return array
   }
 }
 

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -23,6 +23,11 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
           width: 100%;
         }
 
+        .clear {
+          clear: both;
+          margin-bottom: 2.5em;
+        }
+
         .hide {
           display: none;
         }
@@ -111,6 +116,8 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
           label="${this._('Family nick name')}"
         ></grampsjs-form-string>
       </p>
+
+      <div class="clear"></div>
 
       <h4 class="label ${classMap({hide: !this.showMore})}">
         ${this._('Surnames')}

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -180,7 +180,7 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
               icon="more_horiz"
             ></mwc-icon-button>
             <grampsjs-tooltip for="button-show-more" .strings="${this.strings}"
-              >${this._('Show more')}</grampsjs-tooltip
+              >${this._('Show Details')}</grampsjs-tooltip
             >
           `}
     `

--- a/src/components/GrampsjsFormName.js
+++ b/src/components/GrampsjsFormName.js
@@ -127,14 +127,14 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
           <mwc-icon-button
             ?disabled="${!this.data?.surname_list ||
             this.data?.surname_list?.length === 1}"
-            class="edit"
+            class="edit ${classMap({hide: !this.showMore})}"
             icon="delete"
             @click="${() => this._handleDeleteSurname(i)}"
           ></mwc-icon-button>
 
           <mwc-icon-button
             ?disabled="${!this.data?.surname_list || i === 0}"
-            class="edit"
+            class="edit ${classMap({hide: !this.showMore})}"
             icon="arrow_upward"
             @click="${() => this._handleUpSurname(i)}"
           ></mwc-icon-button>
@@ -142,7 +142,7 @@ class GrampsjsFormName extends GrampsjsTranslateMixin(LitElement) {
           <mwc-icon-button
             ?disabled="${!this.data?.surname_list ||
             i === this.data?.surname_list?.length - 1}"
-            class="edit"
+            class="edit ${classMap({hide: !this.showMore})}"
             icon="arrow_downward"
             @click="${() => this._handleDownSurname(i)}"
           ></mwc-icon-button>

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -143,6 +143,9 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
   }
 
   handleChange(e) {
+    if (e.target.disabled) {
+      return
+    }
     const data = e.target.value
     this.dispatchEvent(
       new CustomEvent('formdata:changed', {

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -2,16 +2,24 @@
 Element for selecting a Gramps type
 */
 
-import {html, LitElement} from 'lit'
+import {css, html, LitElement} from 'lit'
 import '@material/mwc-select'
 import '@material/mwc-list/mwc-list-item'
 
+import {classMap} from 'lit/directives/class-map.js'
 import {sharedStyles} from '../SharedStyles.js'
 import {GrampsjsTranslateMixin} from '../mixins/GrampsjsTranslateMixin.js'
 
 class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
   static get styles() {
-    return [sharedStyles]
+    return [
+      sharedStyles,
+      css`
+        .hide {
+          display: none;
+        }
+      `,
+    ]
   }
 
   static get properties() {
@@ -69,7 +77,8 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
         : html`<h4 class="label">${this.heading || this._('Type')}</h4>`}
       <p style="display: flex">
         <mwc-select
-          style="width:100%; ${this._hasCustomType ? 'display: none' : ''}"
+          style="width:100%"
+          class="${classMap({hide: this._hasCustomType})}"
           ?required=${this.required && !this._hasCustomType && !this.nocustom}
           ?disabled=${this.loadingTypes || this._hasCustomType || this.disabled}
           validationMessage="${this._('This field is mandatory')}"

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -124,7 +124,6 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
           ? ''
           : html`
               <mwc-icon-button
-                class="edit"
                 style="margin-left: 8px"
                 icon="${this._hasCustomType ? 'remove' : 'add'}"
                 id="button-switch-type"

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -134,7 +134,7 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
                 for="button-switch-type"
                 content="${this._hasCustomType
                   ? this._('Switch to default type')
-                  : this._('Add custom type')}"
+                  : this._('Switch to custom type')}"
                 .strings="${this.strings}"
               ></grampsjs-tooltip>
             `}

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -129,6 +129,10 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
   }
 
   switchTypeInput() {
+    if (!this._hasCustomType) {
+      const selectType = this.shadowRoot.getElementById('select-type')
+      selectType.value = null
+    }
     this._hasCustomType = !this._hasCustomType
   }
 
@@ -143,9 +147,6 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
   }
 
   handleChange(e) {
-    if (e.target.disabled) {
-      return
-    }
     const data = e.target.value
     this.dispatchEvent(
       new CustomEvent('formdata:changed', {
@@ -158,13 +159,14 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
 
   isValid() {
     const selectType = this.shadowRoot.getElementById('select-type')
-    const customType = this.shadowRoot.getElementById('custom-type') // adding query for custom-type id
-    if (selectType === null && customType === null) {
-      // checking if both types null then return false
+    const customType = this.shadowRoot.getElementById('custom-type')
+    if (selectType === null || (this._hasCustomType && customType === null)) {
       return false
     }
     try {
-      return selectType?.validity?.valid
+      return this._hasCustomType
+        ? customType?.validity?.valid
+        : selectType?.validity?.valid
     } catch {
       return false
     }

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -134,7 +134,7 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
                 for="button-switch-type"
                 content="${this._hasCustomType
                   ? this._('Switch to default type')
-                  : this._('Switch to custom type')}"
+                  : this._('Add custom type')}"
                 .strings="${this.strings}"
               ></grampsjs-tooltip>
             `}

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -124,6 +124,7 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
           ? ''
           : html`
               <mwc-icon-button
+                class="edit"
                 style="margin-left: 8px"
                 icon="${this._hasCustomType ? 'remove' : 'add'}"
                 id="button-switch-type"

--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -67,9 +67,9 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
       ${this.noheading
         ? ''
         : html`<h4 class="label">${this.heading || this._('Type')}</h4>`}
-      <p>
+      <p style="display: flex">
         <mwc-select
-          style="width:100%"
+          style="width:100%; ${this._hasCustomType ? 'display: none' : ''}"
           ?required=${this.required && !this._hasCustomType && !this.nocustom}
           ?disabled=${this.loadingTypes || this._hasCustomType || this.disabled}
           validationMessage="${this._('This field is mandatory')}"
@@ -95,36 +95,41 @@ class GrampsjsFormSelectType extends GrampsjsTranslateMixin(LitElement) {
                 `
               )}
         </mwc-select>
-      </p>
-
-      ${this.nocustom
-        ? ''
-        : html`
-            <mwc-button
-              @click="${this.switchTypeInput}"
-              ?disabled="${this.disabled}"
-            >
-              ${this._hasCustomType
-                ? this._('Switch to default type')
-                : this._('Switch to custom type')}
-            </mwc-button>
-          `}
-      ${this.nocustom || !this._hasCustomType
-        ? ''
-        : html`
-            <h4 class="label">${this._('Custom type')}</h4>
-            <p>
+        ${this.nocustom || !this._hasCustomType
+          ? ''
+          : html`
               <mwc-textfield
                 ?disabled="${this.disabled}"
                 style="width:100%"
-                ?required=${this._hasCustomType}
+                ?required=${this.required}
                 validationMessage="${this._('This field is mandatory')}"
-                @change="${this.handleChange}"
+                @input="${this.handleChange}"
+                label="${this.loadingTypes
+                  ? this._('Loading items...')
+                  : `${this.label} ${this._('Custom')}`}"
                 id="custom-type"
               >
               </mwc-textfield>
-            </p>
-          `}
+            `}
+        ${this.nocustom
+          ? ''
+          : html`
+              <mwc-icon-button
+                style="margin-left: 8px"
+                icon="${this._hasCustomType ? 'remove' : 'add'}"
+                id="button-switch-type"
+                @click="${this.switchTypeInput}"
+                ?disabled="${this.disabled}"
+              ></mwc-icon-button>
+              <grampsjs-tooltip
+                for="button-switch-type"
+                content="${this._hasCustomType
+                  ? this._('Switch to default type')
+                  : this._('Add custom type')}"
+                .strings="${this.strings}"
+              ></grampsjs-tooltip>
+            `}
+      </p>
     `
   }
 

--- a/src/components/GrampsjsFormSurname.js
+++ b/src/components/GrampsjsFormSurname.js
@@ -58,27 +58,6 @@ class GrampsjsFormSurname extends GrampsjsTranslateMixin(LitElement) {
 
   render() {
     return html`
-      ${this.origintype
-        ? html`
-            <p class="${classMap({hide: !this.showMore})}">
-              <grampsjs-form-select-type
-                required
-                noheading
-                label="${this._('Surname origin type:').replace(':', '')}"
-                id="surname-origin-type"
-                .strings="${this.strings}"
-                typeName="name_origin_types"
-                defaultTypeName=""
-                initialValue=${this.data?.origintype || ''}
-                .types="${this.types}"
-                .typesLocale="${this.typesLocale}"
-                ?loadingTypes=${this.loadingTypes}
-                @formdata:changed="${this._handleFormData}"
-              >
-              </grampsjs-form-select-type>
-            </p>
-          `
-        : ''}
       <p class="${classMap({hide: !this.showMore})}">
         <grampsjs-form-string
           @formdata:changed="${this._handleFormData}"
@@ -106,6 +85,26 @@ class GrampsjsFormSurname extends GrampsjsTranslateMixin(LitElement) {
           label="${this._('Surname')}"
         ></grampsjs-form-string>
       </p>
+      ${this.origintype
+        ? html`
+            <p class="${classMap({hide: !this.showMore})}">
+              <grampsjs-form-select-type
+                noheading
+                label="${this._('Surname origin type:').replace(':', '')}"
+                id="surname-origin-type"
+                .strings="${this.strings}"
+                typeName="name_origin_types"
+                defaultTypeName=""
+                initialValue=${this.data?.origintype || ''}
+                .types="${this.types}"
+                .typesLocale="${this.typesLocale}"
+                ?loadingTypes=${this.loadingTypes}
+                @formdata:changed="${this._handleFormData}"
+              >
+              </grampsjs-form-select-type>
+            </p>
+          `
+        : ''}
     `
   }
 

--- a/src/components/GrampsjsFormSurname.js
+++ b/src/components/GrampsjsFormSurname.js
@@ -67,15 +67,6 @@ class GrampsjsFormSurname extends GrampsjsTranslateMixin(LitElement) {
           label="${this._('Prefix')}"
         ></grampsjs-form-string>
       </p>
-      <p class="${classMap({hide: !this.showMore})}">
-        <grampsjs-form-string
-          @formdata:changed="${this._handleFormData}"
-          fullwidth
-          id="connector"
-          value="${this.data.connector || ''}"
-          label="${this._('Connector')}"
-        ></grampsjs-form-string>
-      </p>
       <p>
         <grampsjs-form-string
           @formdata:changed="${this._handleFormData}"
@@ -83,6 +74,15 @@ class GrampsjsFormSurname extends GrampsjsTranslateMixin(LitElement) {
           id="surname"
           value="${this.data.surname || ''}"
           label="${this._('Surname')}"
+        ></grampsjs-form-string>
+      </p>
+      <p class="${classMap({hide: !this.showMore})}">
+        <grampsjs-form-string
+          @formdata:changed="${this._handleFormData}"
+          fullwidth
+          id="connector"
+          value="${this.data.connector || ''}"
+          label="${this._('Connector')}"
         ></grampsjs-form-string>
       </p>
       ${this.origintype

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -131,6 +131,7 @@ export class GrampsjsObjectForm extends GrampsjsTranslateMixin(LitElement) {
         </div>
 
         <mwc-button
+          raised
           slot="primaryAction"
           dialogAction="ok"
           ?disabled="${!this.isValid}"

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -132,6 +132,8 @@ export class GrampsjsObjectForm extends GrampsjsTranslateMixin(LitElement) {
 
         <mwc-button
           raised
+          class="edit"
+          style="margin:8px 16px 8px 8px"
           slot="primaryAction"
           dialogAction="ok"
           ?disabled="${!this.isValid}"
@@ -140,6 +142,8 @@ export class GrampsjsObjectForm extends GrampsjsTranslateMixin(LitElement) {
           ${this._('_Save')}
         </mwc-button>
         <mwc-button
+          class="edit"
+          style="margin:8px"
           slot="secondaryAction"
           dialogAction="cancel"
           @click="${this._handleDialogCancel}"

--- a/src/components/GrampsjsPerson.js
+++ b/src/components/GrampsjsPerson.js
@@ -49,16 +49,17 @@ export class GrampsjsPerson extends GrampsjsObject {
     }
     const surname = this.data.profile.name_surname || html`&hellip;`
     const suffix = this.data.profile.name_suffix || ''
+    const nick = this.data?.primary_name?.nick
     let given = this.data.profile.name_given || html`&hellip;`
     const call = this.data?.primary_name?.call
     const callIndex = call ? given.search(call) : -1
     given =
       callIndex > -1
-        ? html`${given.substr(0, callIndex)}<span class="given-name"
-              >${given.substr(callIndex, call.length)}</span
-            >${given.substr(callIndex + call.length)}`
+        ? html`${given.substring(0, callIndex)}<span class="given-name"
+              >${given.substring(callIndex, call.length)}</span
+            >${given.substring(callIndex + call.length)}`
         : given
-    return html`${given} ${surname} ${suffix}`
+    return html`${given} ${nick ? `"${nick}" ` : ''}${surname} ${suffix}`
   }
 
   _renderBirth() {

--- a/src/components/GrampsjsPerson.js
+++ b/src/components/GrampsjsPerson.js
@@ -49,17 +49,20 @@ export class GrampsjsPerson extends GrampsjsObject {
     }
     const surname = this.data.profile.name_surname || html`&hellip;`
     const suffix = this.data.profile.name_suffix || ''
-    const nick = this.data?.primary_name?.nick
     let given = this.data.profile.name_given || html`&hellip;`
     const call = this.data?.primary_name?.call
     const callIndex = call ? given.search(call) : -1
     given =
       callIndex > -1
-        ? html`${given.substring(0, callIndex)}<span class="given-name"
-              >${given.substring(callIndex, call.length)}</span
-            >${given.substring(callIndex + call.length)}`
+        ? html`
+            ${given.substring(0, callIndex)}
+            <span class="given-name"
+              >${given.substring(callIndex, callIndex + call.length)}</span
+            >
+            ${given.substring(callIndex + call.length)}
+          `
         : given
-    return html`${given} ${nick ? `"${nick}" ` : ''}${surname} ${suffix}`
+    return html`${given} ${surname} ${suffix}`
   }
 
   _renderBirth() {

--- a/src/views/GrampsjsViewObject.js
+++ b/src/views/GrampsjsViewObject.js
@@ -438,7 +438,7 @@ export class GrampsjsViewObject extends GrampsjsView {
     } else if (e.detail.action === 'downName') {
       this.moveName(e.detail.handle, this._data, 'down')
     } else if (e.detail.action === 'delName') {
-      this.delName(e.detail.handle, this._data)
+      this.delName(e.detail.data, this._data)
     } else if (e.detail.action === 'addName') {
       this.addObject(
         e.detail.data,
@@ -591,14 +591,20 @@ export class GrampsjsViewObject extends GrampsjsView {
 
   // for this method, 'handle' is the integer index
   // since names don't have handles!
-  delName(handle, obj) {
+  delName(data, obj) {
+    const {index} = data
     return this._updateObject(obj, 'person', _obj => {
-      if (handle === 1) {
+      if (index === 0) {
+        // keep the entry but delete everything except the name type
+        Object.keys(_obj.primary_name)
+          .filter(key => key !== 'type')
+          .forEach(key => delete _obj.primary_name[key])
+      } else if (index === 1) {
         _obj.alternate_names = [..._obj.alternate_names.slice(1)]
-      } else if (handle > 1) {
+      } else if (index > 1) {
         _obj.alternate_names = [
-          ..._obj.alternate_names.slice(0, handle - 1),
-          ..._obj.alternate_names.slice(handle),
+          ..._obj.alternate_names.slice(0, index - 1),
+          ..._obj.alternate_names.slice(index),
         ]
       }
       return _obj


### PR DESCRIPTION
Added some fixes and improvements in names' edit handling.

Fixes:
- name-type not selected
- fix show-more feature

Features:
- add sort to surname
- add delete to name and surname

UX/UI improvements:
- use editable list for names
- add name edit form validation
- improve name-type vs. custom-type handling
- some minor styling

Fixes:
- https://github.com/gramps-project/gramps-web/issues/149
- https://github.com/gramps-project/gramps-web/issues/123