### PR TITLE
Render GrampsjsFaces even if face_detection fails (fixes #424)

### DIFF
--- a/src/components/GrampsjsConnectedComponent.js
+++ b/src/components/GrampsjsConnectedComponent.js
@@ -30,6 +30,7 @@ export class GrampsjsConnectedComponent extends GrampsjsTranslateMixin(
     super()
     this.loading = true
     this.error = false
+    this.renderOnError = false
     this.loadWithoutLocale = false
     this._errorMessage = ''
     this._data = {}
@@ -47,7 +48,9 @@ export class GrampsjsConnectedComponent extends GrampsjsTranslateMixin(
           detail: {message: this._errorMessage},
         })
       )
-      return ''
+      if (!this.renderOnError) {
+        return ''
+      }
     }
     if (this.loading) {
       return this.renderLoading()

--- a/src/components/GrampsjsFaces.js
+++ b/src/components/GrampsjsFaces.js
@@ -37,6 +37,9 @@ export class GrampsjsFaces extends GrampsjsConnectedComponent {
 
   // slightly grow rectangles and make them rectangular
   _getFaces() {
+    if (!this._data.data) {
+      return []
+    }
     return this._data.data.map(rect => {
       const [left, top, right, bottom] = rect
       const width = right - left
@@ -65,6 +68,7 @@ export class GrampsjsFaces extends GrampsjsConnectedComponent {
     this.selectedRect = []
     this.deletedRects = []
     this.rectHidden = false
+    this.renderOnError = true // render even if face detection fails
   }
 
   getUrl() {


### PR DESCRIPTION
These changes avoid a TypeError when face_detection fails and allow any classes extending GrampsjsConnectedComponent to render even if it's in a failed state.