### PR TITLE
Fix editing source attributes

### DIFF
--- a/src/components/GrampsjsAttributes.js
+++ b/src/components/GrampsjsAttributes.js
@@ -10,6 +10,17 @@ import '@material/mwc-list/mwc-list-item'
 import {fireEvent} from '../util.js'
 
 export class GrampsjsAttributes extends GrampsjsEditableList {
+  static get properties() {
+    return {
+      source: {type: Boolean},
+    }
+  }
+
+  constructor() {
+    super()
+    this.source = false
+  }
+
   row(obj) {
     return html`
       <mwc-list-item
@@ -28,6 +39,7 @@ export class GrampsjsAttributes extends GrampsjsEditableList {
   _handleAdd() {
     this.dialogContent = html`
       <grampsjs-form-edit-attribute
+        ?source="${this.source}"
         new
         @object:save="${this._handleAttrSave}"
         @object:cancel="${this._handleAttrCancel}"
@@ -40,11 +52,15 @@ export class GrampsjsAttributes extends GrampsjsEditableList {
   _handleEdit() {
     const attr = this.data[this._selectedIndex]
     const data = {
-      type: {_class: 'AttributeType', string: attr.type || ''},
+      type: {
+        _class: this.source ? 'SrcAttributeType' : 'AttributeType',
+        string: attr.type || '',
+      },
       value: attr.value || '',
     }
     this.dialogContent = html`
       <grampsjs-form-edit-attribute
+        ?source="${this.source}"
         @object:save="${this._handleAttrSaveEdit}"
         @object:cancel="${this._handleAttrCancel}"
         .strings="${this.strings}"

--- a/src/components/GrampsjsFormEditAttribute.js
+++ b/src/components/GrampsjsFormEditAttribute.js
@@ -10,11 +10,22 @@ import './GrampsjsFormSelectType.js'
 import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 
 class GrampsjsFormEditAttribute extends GrampsjsObjectForm {
+  static get properties() {
+    return {
+      source: {type: Boolean},
+    }
+  }
+
+  constructor() {
+    super()
+    this.source = false
+  }
+
   renderForm() {
     return html`
       <grampsjs-form-select-type
         required
-        id="attrtype"
+        id="${this.source ? 'srcattrtype' : 'attrtype'}"
         heading="${this._('Type')}"
         .strings="${this.strings}"
         typeName="attribute_types"

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -511,6 +511,7 @@ export class GrampsjsObject extends GrampsjsTranslateMixin(LitElement) {
           .strings=${this.strings}
           ?edit="${this.edit}"
           .data=${this.data.attribute_list}
+          ?source="${this._objectsName === 'Sources'}"
         ></grampsjs-attributes>`
       case 'addresses':
         return html`<grampsjs-addresses

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -345,6 +345,12 @@ export class GrampsjsObjectForm extends GrampsjsTranslateMixin(LitElement) {
     if (originalTarget.id === 'name') {
       this.data = e.detail.data
     }
+    if (originalTarget.id === 'srcattrtype') {
+      this.data = {
+        ...this.data,
+        type: {_class: 'SrcAttributeType', string: e.detail.data},
+      }
+    }
     if (originalTarget.id === 'attrtype') {
       this.data = {
         ...this.data,


### PR DESCRIPTION
I noticed adding and editing attributes on sources was broken because we didn't handle the distinction between AttributeType and SrcAttributeType.