### PR TITLE
Use credentials to request manifest.json file

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="fonts/fonts.css">
   <link rel="stylesheet" href="tippy.css">
   <link rel="icon" href="images/favicon.ico">
-  <link rel="manifest" href="manifest.json">
+  <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
   <meta name="theme-color" content="#6D4C41">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="application-name" content="Gramps">


### PR DESCRIPTION
This is needed to properly fetch the manifest.json file when Gramps runs behind an authenticating proxy like Pomerium or Cloudflare Zero Trust, as documented here: https://web.dev/articles/add-manifest#link-manifest

Without that the request for the manifest.json file is done without the cookies set by the proxy (CF_AppSession and CF_Authorization in the case of Cloudflare) and the request gets redirected to the proxy login page.

As you can guess, I'm running Gramps behind Cloudflare Zero Trust (and Pomerium before that). I'm running into some issues that I am still investigating, but this one seemed simple enough to solve.