### PR TITLE
Ignore index.html in service worker cache

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ const baseConfig = createSpaConfig({
   developmentMode: process.env.ROLLUP_WATCH === 'true',
   injectServiceWorker: true,
   workbox: {
+    globIgnores: ['index.html'],
     navigateFallbackDenylist: [/^\/api.*/],
     skipWaiting: false,
     clientsClaim: false,


### PR DESCRIPTION
Fixes #517

By default, index.html is cached by the service worker. This breaks the application if it's hosted behind an authentifying proxy which requires periodic revalidation of an auth token. Specifically, once the auth token expires:
1. The index.html is still served from the service worker cache.
2. Subsequent requests (e.g for JS resources) are redirected to the login page of the proxy.
3. That login page is never displayed to the user as index.html has been successfully loaded.
4. All requests but index.html fail, and the app displays a blank page.

This change fixes this behavior by preventing index.html from being cached by the service worker. With that change, once the auth token from the proxy expires:
1. The request for index.html is not served from the service worker cache.
2. Instead, a network request for index.html is made, and the user is properly redirected to the proxy login page.
3. The user logs in, and index.html is served as normal.
4. Subsequent requests (e.g for JS resources) succeed as now the auth token has been refreshed.