### PR TITLE
Add user information to settings pages

### DIFF
--- a/src/components/GrampsjsSysinfo.js
+++ b/src/components/GrampsjsSysinfo.js
@@ -31,18 +31,20 @@ export class GrampsjsSysinfo extends GrampsjsTranslateMixin(LitElement) {
   static get properties() {
     return {
       data: {type: Object},
+      tree: {type: String},
     }
   }
 
   constructor() {
     super()
     this.data = {}
+    this.tree = ''
   }
 
   render() {
     const version = '[VI]{version}[/VI]'
     return html`
-      <div class="copy" id="copy">
+      <div class="copy">
         <mwc-icon-button
           icon="content_copy"
           id="copy-button"
@@ -51,17 +53,21 @@ export class GrampsjsSysinfo extends GrampsjsTranslateMixin(LitElement) {
         <grampsjs-tooltip for="copy-button" .strings="${this.strings}"
           >${this._('Copy to clipboard')}</grampsjs-tooltip
         >
-        Gramps ${this.data?.gramps?.version || '?'}<br />
-        Gramps Web API ${this.data?.gramps_webapi?.version || '?'}<br />
-        Gramps Web Frontend ${version}<br />
-        Gramps QL ${this.data?.gramps_ql?.version || '?'}<br />
-        Sifts ${this.data?.search?.sifts?.version || '?'}<br />
-        locale: ${this.data?.locale?.language}<br />
-        multi-tree: ${this.data?.server?.multi_tree}<br />
-        task queue: ${this.data?.server?.task_queue}<br />
-        OCR: ${this.data?.server?.ocr}<br />
-        chat: ${this.data?.server?.chat}<br />
+        <span id="copy">
+          Gramps ${this.data?.gramps?.version || '?'}<br />
+          Gramps Web API ${this.data?.gramps_webapi?.version || '?'}<br />
+          Gramps Web Frontend ${version}<br />
+          Gramps QL ${this.data?.gramps_ql?.version || '?'}<br />
+          Sifts ${this.data?.search?.sifts?.version || '?'}<br />
+          locale: ${this.data?.locale?.language}<br />
+          multi-tree: ${this.data?.server?.multi_tree}<br />
+          task queue: ${this.data?.server?.task_queue}<br />
+          OCR: ${this.data?.server?.ocr}<br />
+          chat: ${this.data?.server?.chat}<br />
+        </span>
       </div>
+      <hr />
+      <div class="copy">Tree: ${this.tree}</div>
     `
   }
 

--- a/src/views/GrampsjsViewSettings.js
+++ b/src/views/GrampsjsViewSettings.js
@@ -3,6 +3,7 @@ import {css, html} from 'lit'
 import {GrampsjsViewSettingsOnboarding} from './GrampsjsViewSettingsOnboarding.js'
 import './GrampsjsViewAdminSettings.js'
 import './GrampsjsViewUserManagement.js'
+import {userRoles} from '../components/GrampsjsFormUser.js'
 import '../components/GrampsjsUsers.js'
 import '../components/GrampsjsTaskProgressIndicator.js'
 import '../components/GrampsjsShareUrl.js'
@@ -136,6 +137,10 @@ export class GrampsjsViewSettings extends GrampsjsViewSettingsOnboarding {
 
   renderUserSettings() {
     return html`
+      <h3>
+        ${this._('Username: ')} ${this._userInfo?.name} ${this._('Role')}:
+        ${this._(userRoles[this._userInfo?.role])}
+      </h3>
       ${renderLogoutButton()}
 
       <h3>${this._('Select language')}</h3>
@@ -163,6 +168,8 @@ export class GrampsjsViewSettings extends GrampsjsViewSettingsOnboarding {
       <grampsjs-sysinfo
         .data="${this.dbInfo}"
         .strings="${this.strings}"
+        .userInfo="${this._userInfo}"
+        .tree="${getTreeId()}"
       ></grampsjs-sysinfo>
     `
   }


### PR DESCRIPTION
closes #376 
![Extended SystemInfo](https://github.com/user-attachments/assets/a1bfc44a-9751-4e92-95ce-02306af37c90)
![Extended Logout](https://github.com/user-attachments/assets/cdf50d23-a01e-49dd-a5f2-977e0a306d4f)

- [X]     The Username and permissions level should show beside the "LOGOUT" button in User Settings
- [X]     The tree ID, username and permissions level should be included in the System Information that can be "Copy to clipboard"
- [X]     tree ID & username should not be in the copied data as they can represent personally identifiable information.
