### PR TITLE
Display alternative place names

### DIFF
--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -22,6 +22,7 @@ import './GrampsjsIcon.js'
 import './GrampsjsNames.js'
 import './GrampsjsPlaceChildren.js'
 import './GrampsjsPlaceRefs.js'
+import './GrampsjsPlaceNames.js'
 import './GrampsjsGallery.js'
 import './GrampsjsMap.js'
 import './GrampsjsMapMarker.js'
@@ -56,6 +57,11 @@ const _allTabs = {
       data.placeref_list?.length > 0 ||
       ('placeref_list' in data && data?.backlinks?.place?.length >= 0),
     conditionEdit: data => 'placeref_list' in data,
+  },
+  placeNames: {
+    title: 'Alternate Names',
+    condition: data => data.alt_names?.length > 0,
+    conditionEdit: data => data.alt_names?.length > 0,
   },
   map: {
     title: 'Map',
@@ -584,6 +590,14 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
             ?edit=${this.edit}
           ></grampsjs-names>
         `
+      case 'placeNames':
+        return html` ${this.data.alt_names?.length > 0
+          ? html` <grampsjs-place-names
+              .strings="${this.strings}"
+              .data="${this.data.alt_names}"
+              ?edit=${false}
+            ></grampsjs-place-names>`
+          : ''}`
       case 'enclosed':
         return html` ${this.data.placeref_list?.length || this.edit
           ? html`

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -60,8 +60,8 @@ const _allTabs = {
   },
   placeNames: {
     title: 'Alternate Names',
-    condition: data => data.alt_names?.length > 0,
-    conditionEdit: data => data.alt_names?.length > 0,
+    condition: data => data?.alt_names?.length > 0,
+    conditionEdit: data => data?.alt_names?.length > 0,
   },
   map: {
     title: 'Map',

--- a/src/components/GrampsjsPlaceNames.js
+++ b/src/components/GrampsjsPlaceNames.js
@@ -1,0 +1,34 @@
+import {html} from 'lit'
+
+import '@material/mwc-icon-button'
+import '@material/mwc-dialog'
+import '@material/mwc-button'
+import {toDate} from '../date.js'
+import {dateIsEmpty} from '../util.js'
+import {GrampsjsEditableTable} from './GrampsjsEditableTable.js'
+
+export class GrampsjsPlaceNames extends GrampsjsEditableTable {
+  constructor() {
+    super()
+    this.objType = 'PlaceName'
+    this._columns = ['Name', 'Date', '']
+    this.dialogContent = ''
+    this.edit = false
+  }
+
+  row(obj, i, arr) {
+    return html`
+      <tr>
+        <td>${obj.value}</td>
+        <td>${dateIsEmpty(obj.date) ? '' : toDate(obj.date?.dateval)}</td>
+        <td>
+          ${false // ${this.edit TODO: implement place name edit
+            ? this._renderActionBtns(obj.ref, i === 0, i === arr.length - 1)
+            : ''}
+        </td>
+      </tr>
+    `
+  }
+}
+
+window.customElements.define('grampsjs-place-names', GrampsjsPlaceNames)

--- a/src/strings.js
+++ b/src/strings.js
@@ -103,6 +103,7 @@ export const grampsStrings = [
   'Aide',
   'Album',
   'Also Known As',
+  'Alternate Names',
   'Alternate Marriage',
   'Ancestor Tree',
   'and',


### PR DESCRIPTION
This is my first contribution and an attempt to solve issue: https://github.com/gramps-project/gramps-web/issues/27

I have decided to only tackle displaying alternative place names and not implementing edit functionality. This will be added in a future PR.

Any feedback or suggestions welcome

## Screenshots
Place view when alternative name is present
<img width="1552" alt="Screenshot 2025-01-05 at 20 53 26" src="https://github.com/user-attachments/assets/4b60303a-0d61-43a0-96aa-d5acb06b6c9f" />
Alternative name Tab when alternative name is present
<img width="1552" alt="Screenshot 2025-01-05 at 20 53 28" src="https://github.com/user-attachments/assets/a347ed83-e604-4f41-a816-7686724c304b" />
Alternative name Tab when alternative name is present and in edit mode
<img width="1552" alt="Screenshot 2025-01-05 at 20 53 31" src="https://github.com/user-attachments/assets/e06a7072-aa52-412d-b279-b9e795e30987" />
Place view when alternative name is not present
<img width="1552" alt="Screenshot 2025-01-05 at 20 53 37" src="https://github.com/user-attachments/assets/636b0c84-9dc1-41c2-a0fe-846e6e7ed4db" />
Place view when alternative name is not present and in edit mode
<img width="1552" alt="Screenshot 2025-01-05 at 20 53 40" src="https://github.com/user-attachments/assets/dc8243cf-ca3a-446d-b530-181b5dd11a57" />

