### PR TITLE
Handle date must not be null in Gramps 6 (#631)

### DIFF
--- a/src/components/GrampsjsCitation.js
+++ b/src/components/GrampsjsCitation.js
@@ -4,7 +4,7 @@ import '@material/mwc-icon'
 
 import {GrampsjsObject} from './GrampsjsObject.js'
 import './GrampsjsFormEditCitationDetails.js'
-import {fireEvent, linkUrls} from '../util.js'
+import {fireEvent, linkUrls, emptyDate} from '../util.js'
 
 const BASE_DIR = ''
 
@@ -88,7 +88,7 @@ export class GrampsjsCitation extends GrampsjsObject {
 
   _handleEditDetails() {
     const data = {
-      date: this.data.date,
+      date: this.data.date ?? emptyDate,
       confidence: this.data.confidence,
       source_handle: this.data.source_handle,
       page: this.data.page,

--- a/src/components/GrampsjsEvent.js
+++ b/src/components/GrampsjsEvent.js
@@ -6,7 +6,7 @@ import {GrampsjsObject} from './GrampsjsObject.js'
 import './GrampsjsFormEditEventDetails.js'
 import './GrampsjsFormEditTitle.js'
 import './GrampsjsTooltip.js'
-import {fireEvent} from '../util.js'
+import {fireEvent, emptyDate} from '../util.js'
 
 const BASE_DIR = ''
 
@@ -141,7 +141,7 @@ export class GrampsjsEvent extends GrampsjsObject {
   }
 
   _handleEditDetails() {
-    const data = {date: this.data.date}
+    const data = {date: this.data.date ?? emptyDate}
     if (this.data.place) {
       data.place = this.data.place
     }

--- a/src/components/GrampsjsFormNewMedia.js
+++ b/src/components/GrampsjsFormNewMedia.js
@@ -1,7 +1,7 @@
 import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 import {GrampsjsNewMediaMixin} from '../mixins/GrampsjsNewMediaMixin.js'
 
-import {fireEvent} from '../util.js'
+import {fireEvent, emptyDate} from '../util.js'
 
 export class GrampsjsFormNewMedia extends GrampsjsNewMediaMixin(
   GrampsjsObjectForm
@@ -20,7 +20,7 @@ export class GrampsjsFormNewMedia extends GrampsjsNewMediaMixin(
     super._handleFormData(e)
     const originalTarget = e.composedPath()[0]
     if (originalTarget.id === 'date') {
-      this.data = {...this.data, date: e.detail.data}
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
     }
     if (originalTarget.id === 'upload') {
       this.data = {

--- a/src/components/GrampsjsFormSelectDate.js
+++ b/src/components/GrampsjsFormSelectDate.js
@@ -8,7 +8,7 @@ import '@material/mwc-select'
 import '@material/mwc-list/mwc-list-item'
 
 import {sharedStyles} from '../SharedStyles.js'
-import {getSortval, dateIsEmpty} from '../util.js'
+import {getSortval, dateIsEmpty, emptyDate} from '../util.js'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 
 const modifiers = {
@@ -29,14 +29,7 @@ const qualifiers = {
   2: 'Calculated',
 }
 
-const dataDefault = {
-  _class: 'Date',
-  calendar: 0,
-  modifier: 0,
-  quality: 0,
-  dateval: [0, 0, 0, false],
-  sortval: 0,
-}
+const dataDefault = {...emptyDate}
 
 function parseDate(s) {
   if (!s) {

--- a/src/components/GrampsjsMediaObject.js
+++ b/src/components/GrampsjsMediaObject.js
@@ -10,7 +10,7 @@ import './GrampsjsFormEditMapLayer.js'
 import './GrampsjsFormSelectObject.js'
 import './GrampsjsFaces.js'
 import './GrampsjsTextRecognition.js'
-import {arrayEqual, fireEvent, getNameFromProfile} from '../util.js'
+import {arrayEqual, fireEvent, getNameFromProfile, emptyDate} from '../util.js'
 import {renderIconSvg} from '../icons.js'
 
 import '@material/mwc-dialog'
@@ -422,7 +422,7 @@ export class GrampsjsMediaObject extends GrampsjsObject {
       @object:save="${this._handleSaveDate}"
       @object:cancel="${this._handleCancelDialog}"
       .appState="${this.appState}"
-      .data=${{date: this.data.date}}
+      .data=${{date: this.data.date ?? emptyDate}}
     >
     </grampsjs-form-edit-title>
     `

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -9,7 +9,7 @@ import '@material/mwc-button'
 import '@material/mwc-circular-progress'
 
 import {sharedStyles} from '../SharedStyles.js'
-import {fireEvent} from '../util.js'
+import {fireEvent, emptyDate} from '../util.js'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 
 export class GrampsjsObjectForm extends GrampsjsAppStateMixin(LitElement) {
@@ -289,7 +289,7 @@ export class GrampsjsObjectForm extends GrampsjsAppStateMixin(LitElement) {
       this.data = {...this.data, raw_data: [e.detail.data]}
     }
     if (originalTarget.id === 'date') {
-      this.data = {...this.data, date: e.detail.data}
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
     }
     if (originalTarget.id === 'event-role-type') {
       this.data = {

--- a/src/util.js
+++ b/src/util.js
@@ -13,6 +13,15 @@ dayjs.extend(relativeTime)
 
 const BASE_DIR = ''
 
+export const emptyDate = {
+  _class: 'Date',
+  calendar: 0,
+  modifier: 0,
+  quality: 0,
+  dateval: [0, 0, 0, false],
+  sortval: 0,
+}
+
 export function translate(strings, s) {
   if (s === undefined) {
     return ''

--- a/src/views/GrampsjsViewNewCitation.js
+++ b/src/views/GrampsjsViewNewCitation.js
@@ -5,6 +5,7 @@ import '@material/mwc-textfield'
 import {GrampsjsViewNewObject} from './GrampsjsViewNewObject.js'
 import '../components/GrampsjsFormString.js'
 import '../components/GrampsjsFormPrivate.js'
+import {emptyDate} from '../util.js'
 
 export const confidence = {
   0: 'Very Low',
@@ -94,7 +95,7 @@ export class GrampsjsViewNewCitation extends GrampsjsViewNewObject {
       this.data = {...this.data, source_handle: e.detail.data[0]}
     }
     if (originalTarget.id === 'date') {
-      this.data = {...this.data, date: e.detail.data}
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
     }
     this.checkFormValidity()
   }

--- a/src/views/GrampsjsViewNewEvent.js
+++ b/src/views/GrampsjsViewNewEvent.js
@@ -14,6 +14,8 @@ import '../components/GrampsjsFormSelectObjectList.js'
 import '../components/GrampsjsFormSelectType.js'
 import '../components/GrampsjsFormPrivate.js'
 
+import {emptyDate} from '../util.js'
+
 export class GrampsjsViewNewEvent extends GrampsjsNewEventMixin(
   GrampsjsViewNewObject
 ) {
@@ -51,7 +53,7 @@ export class GrampsjsViewNewEvent extends GrampsjsNewEventMixin(
       this.data = {...this.data, place: e.detail.data[0]}
     }
     if (originalTarget.id === 'date') {
-      this.data = {...this.data, date: e.detail.data}
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
     }
     if (originalTarget.id === 'private') {
       this.data = {...this.data, private: e.detail.checked}

--- a/src/views/GrampsjsViewNewMedia.js
+++ b/src/views/GrampsjsViewNewMedia.js
@@ -6,6 +6,8 @@ import {GrampsjsNewMediaMixin} from '../mixins/GrampsjsNewMediaMixin.js'
 
 import {GrampsjsViewNewObject} from './GrampsjsViewNewObject.js'
 
+import {emptyDate} from '../util.js'
+
 export class GrampsjsViewNewMedia extends GrampsjsNewMediaMixin(
   GrampsjsViewNewObject
 ) {
@@ -42,7 +44,7 @@ export class GrampsjsViewNewMedia extends GrampsjsNewMediaMixin(
     super._handleFormData(e)
     const originalTarget = e.composedPath()[0]
     if (originalTarget.id === 'date') {
-      this.data = {...this.data, date: e.detail.data}
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
     }
     if (originalTarget.id === 'upload') {
       this.data = {

--- a/src/views/GrampsjsViewNewPerson.js
+++ b/src/views/GrampsjsViewNewPerson.js
@@ -4,7 +4,7 @@ import {GrampsjsViewNewObject} from './GrampsjsViewNewObject.js'
 import '../components/GrampsjsFormName.js'
 import '../components/GrampsjsFormPrivate.js'
 import '../components/GrampsjsFormSelectObjectList.js'
-import {makeHandle, dateIsEmpty} from '../util.js'
+import {makeHandle, dateIsEmpty, emptyDate} from '../util.js'
 
 const gender = {
   2: 'Unknown',
@@ -105,7 +105,7 @@ export class GrampsjsViewNewPerson extends GrampsjsViewNewObject {
     if (originalTarget.id === 'birth-date') {
       this.data = {
         ...this.data,
-        birth: {...this.data.birth, date: e.detail.data},
+        birth: {...this.data.birth, date: e.detail.data ?? emptyDate},
       }
     }
     if (originalTarget.id === 'birth-place-list') {
@@ -117,7 +117,7 @@ export class GrampsjsViewNewPerson extends GrampsjsViewNewObject {
     if (originalTarget.id === 'death-date') {
       this.data = {
         ...this.data,
-        death: {...this.data.death, date: e.detail.data},
+        death: {...this.data.death, date: e.detail.data ?? emptyDate},
       }
     }
     if (originalTarget.id === 'death-place-list') {


### PR DESCRIPTION
This should fix (most of?) the cases where the date property of Gramps obejcts can end up being `null`; it is now set explicitly to an empty date object as required by Gramps 6.