### PR TITLE
Fix hyperlink on Family Tree page when no home person is set

### DIFF
--- a/src/views/GrampsjsViewTree.js
+++ b/src/views/GrampsjsViewTree.js
@@ -81,7 +81,7 @@ export class GrampsjsViewTree extends GrampsjsView {
         <div class="with-margin">
           <p>
             ${this._('No Home Person set.')}
-            <a href="/settings">${this._('User settings')}</a>
+            <a href="/">${this._('Home Page')}</a>
           </p>
         </div>
       `


### PR DESCRIPTION
When you moved the SELECT Home Person widget (#500), the hyperlink on the Family Tree page was still pointing to the User Settings page.

This pull request points it to the Home Page where the SELECT Home Person widget now resides.