### PR TITLE
Toggle person outlines on photos

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -221,5 +221,6 @@
   "semantic": "semantic",
   "Name Display Format": "Name Display Format",
   "Surname First": "Surname First",
-  "Given Name First": "Given Name First"
+  "Given Name First": "Given Name First",
+  "Toggle person outlines": "Toggle person outlines"
 }

--- a/src/components/GrampsjsRect.js
+++ b/src/components/GrampsjsRect.js
@@ -109,7 +109,11 @@ class GrampsjsRect extends LitElement {
     const height = this.rect[3] - this.rect[1]
     return html`
       <div
-        class="rect ${classMap({selected: this.selected, muted: this.muted, hidden: this.hidden})}"
+        class="rect ${classMap({
+          selected: this.selected,
+          muted: this.muted,
+          hidden: this.hidden,
+        })}"
         @click="${this._handleClick}"
         @keydown=""
         style="left:${left}%;top:${top}%;width:${width}%;height:${height}%;"

--- a/src/components/GrampsjsRect.js
+++ b/src/components/GrampsjsRect.js
@@ -42,6 +42,14 @@ class GrampsjsRect extends LitElement {
           box-shadow: None;
         }
 
+        .rect.hidden:not(.selected) {
+          opacity: 0;
+        }
+
+        .rect.hidden:hover {
+          opacity: 1;
+        }
+
         @media (hover: hover) {
           .rect .label {
             background-color: rgba(0.5, 0.5, 0.5, 0.25);
@@ -77,6 +85,7 @@ class GrampsjsRect extends LitElement {
       target: {type: String},
       selected: {type: Boolean},
       muted: {type: Boolean},
+      hidden: {type: Boolean},
     }
   }
 
@@ -87,6 +96,7 @@ class GrampsjsRect extends LitElement {
     this.target = ''
     this.selected = false
     this.muted = false
+    this.hidden = false
   }
 
   render() {
@@ -99,7 +109,7 @@ class GrampsjsRect extends LitElement {
     const height = this.rect[3] - this.rect[1]
     return html`
       <div
-        class="rect ${classMap({selected: this.selected, muted: this.muted})}"
+        class="rect ${classMap({selected: this.selected, muted: this.muted, hidden: this.hidden})}"
         @click="${this._handleClick}"
         @keydown=""
         style="left:${left}%;top:${top}%;width:${width}%;height:${height}%;"

--- a/src/components/GrampsjsTooltip.js
+++ b/src/components/GrampsjsTooltip.js
@@ -67,6 +67,7 @@ export class GrampsjsTooltip extends GrampsjsAppStateMixin(LitElement) {
     const options = {
       content: this.innerHTML,
       allowHTML: true,
+      zIndex: 19999,
     }
     if (this.theme) {
       options.theme = this.theme

--- a/src/strings.js
+++ b/src/strings.js
@@ -583,6 +583,7 @@ export const grampsStrings = [
   'Title',
   'To Do',
   'to',
+  'Toggle person outlines',
   'Tombstone',
   'Top Left',
   'Top paper margin',

--- a/src/strings.js
+++ b/src/strings.js
@@ -583,7 +583,6 @@ export const grampsStrings = [
   'Title',
   'To Do',
   'to',
-  'Toggle person outlines',
   'Tombstone',
   'Top Left',
   'Top paper margin',

--- a/src/views/GrampsjsViewMediaLightbox.js
+++ b/src/views/GrampsjsViewMediaLightbox.js
@@ -77,9 +77,9 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
             .icon="${this.rectHidden ? 'person' : 'person_off'}"
             @click="${this._handleToggleRectButtonClick}"
           ></mwc-icon-button>
-          <grampsjs-tooltip
-            for="btn-toggle-rect"
-          >${this._('Toggle person outlines')}</grampsjs-tooltip>
+          <grampsjs-tooltip for="btn-toggle-rect"
+            >${this._('Toggle person outlines')}</grampsjs-tooltip
+          >
           <mwc-icon-button
             icon="download"
             class="download"

--- a/src/views/GrampsjsViewMediaLightbox.js
+++ b/src/views/GrampsjsViewMediaLightbox.js
@@ -4,6 +4,7 @@ import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsLightbox.js'
 import '../components/GrampsjsRectContainer.js'
 import '../components/GrampsjsRect.js'
+import '../components/GrampsjsTooltip.js'
 import {getMediaUrl} from '../api.js'
 import {fireEvent, getNameFromProfile} from '../util.js'
 
@@ -24,6 +25,7 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
           padding-left: 0.8em;
         }
 
+        mwc-icon-button.toggle-rect,
         mwc-icon-button.download {
           color: var(--mdc-theme-primary);
           position: relative;
@@ -41,6 +43,7 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
       hideLeftArrow: {type: Boolean},
       hideRightArrow: {type: Boolean},
       editRect: {type: Boolean},
+      rectHidden: {type: Boolean},
     }
   }
 
@@ -50,6 +53,7 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
     this.hideLeftArrow = false
     this.hideRightArrow = false
     this.editRect = false
+    this.rectHidden = false
   }
 
   renderContent() {
@@ -67,6 +71,15 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
             : ''}</span
         >
         <span slot="button">
+          <mwc-icon-button
+            id="btn-toggle-rect"
+            class="toggle-rect"
+            .icon="${this.rectHidden ? 'person' : 'person_off'}"
+            @click="${this._handleToggleRectButtonClick}"
+          ></mwc-icon-button>
+          <grampsjs-tooltip
+            for="btn-toggle-rect"
+          >${this._('Toggle person outlines')}</grampsjs-tooltip>
           <mwc-icon-button
             icon="download"
             class="download"
@@ -142,6 +155,7 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
         obj => html`
           <grampsjs-rect
             .rect="${obj.rect}"
+            .hidden="${this.rectHidden}"
             label="${obj.label}"
             target="${obj.type}/${obj.grampsId}"
           >
@@ -179,6 +193,10 @@ export class GrampsjsViewMediaLightbox extends GrampsjsView {
         },
       })
     )
+  }
+
+  _handleToggleRectButtonClick() {
+    this.rectHidden = !this.rectHidden
   }
 
   _handleSaveRect(e) {


### PR DESCRIPTION
I added a toggle button that shows/hides (opacity: 0) the person outline rectangles in the lightbox view. When hidden, the person outline rectangles will only show when you hover over them with your mouse.

I tried a switch (mwc-switch instead of mwc-icon-button) first but it took up too much of the limited real estate in the bottom right corner.

This should fix #605.

Feedback or suggestions welcome - this is my first PR for this project.

![localhost_5555_person_I0880 (1)](https://github.com/user-attachments/assets/d91c9ae9-cb9b-490c-be90-977c1866f4df)
