### PR TITLE
Fixed missing translation for key string not present in backend language files

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -223,5 +223,6 @@
   "Surname First": "Surname First",
   "Given Name First": "Given Name First",
   "Toggle person outlines": "Toggle person outlines",
-  "Log out": "Log out"
+  "Log out": "Log out",
+  "in": "in"
 }

--- a/src/strings.js
+++ b/src/strings.js
@@ -299,7 +299,6 @@ export const grampsStrings = [
   'Immigration',
   'Import Family Tree',
   'Import',
-  'in',
   'Informant',
   'Inherited',
   'Italic',


### PR DESCRIPTION
Translation key string "in" is not relevant to Gramps backend app resulting to missing translation.
Translation moved  to frontend json file.
![Missing translation](https://github.com/user-attachments/assets/e8bd0847-50b4-4927-aa41-286dc7c466a5)
