### PR TITLE
Get rid of tabs in object view

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -228,5 +228,6 @@
   "DNA matches": "DNA matches",
   "Base Map": "Base Map",
   "Historical Map": "Historical Map",
-  "To start building your family tree, add yourself as a person or import a family tree file.": "To start building your family tree, add yourself as a person or import a family tree file."
+  "To start building your family tree, add yourself as a person or import a family tree file.": "To start building your family tree, add yourself as a person or import a family tree file.",
+  "Metadata": "Metadata"
 }

--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -66,7 +66,6 @@ export class GrampsJs extends LitElement {
   constructor() {
     super()
     this.appState = getInitialAppState()
-    this.wide = false
     this.progress = false
     this.loadingState = LOADING_STATE_INITIAL
     this._homePersonDetails = {}
@@ -474,9 +473,9 @@ export class GrampsJs extends LitElement {
     }
     return html`
       <mwc-drawer
-        type="${this.wide ? 'dismissible' : 'modal'}"
+        type="${this.appState.screenSize !== 'small' ? 'dismissible' : 'modal'}"
         id="app-drawer"
-        ?open="${this.wide}"
+        ?open="${this.appState.screenSize !== 'small'}"
       >
         <div>
           <grampsjs-main-menu .appState="${this.appState}"></grampsjs-main-menu>
@@ -555,8 +554,23 @@ export class GrampsJs extends LitElement {
     installRouter(location =>
       this._loadPage(decodeURIComponent(location.pathname))
     )
-    installMediaQueryWatcher('(min-width: 768px)', matches => {
-      this.wide = matches
+    installMediaQueryWatcher('(max-width: 991px)', matches => {
+      if (matches && this.appState.screenSize !== 'small') {
+        this._updateAppState({screenSize: 'small'})
+      }
+    })
+    installMediaQueryWatcher(
+      '(min-width: 992px) and (max-width: 1199px)',
+      matches => {
+        if (matches && this.appState.screenSize !== 'medium') {
+          this._updateAppState({screenSize: 'medium'})
+        }
+      }
+    )
+    installMediaQueryWatcher('(min-width: 1200px)', matches => {
+      if (matches && this.appState.screenSize !== 'large') {
+        this._updateAppState({screenSize: 'large'})
+      }
     })
     this.addEventListener('nav', this._handleNav.bind(this))
     this.addEventListener('grampsjs:error', this._handleError.bind(this))
@@ -724,7 +738,7 @@ export class GrampsJs extends LitElement {
       })
     }
 
-    if (!this.wide) {
+    if (this.appState.screenSize === 'small') {
       this._closeDrawer()
     }
   }

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -9,7 +9,7 @@ export const sharedStyles = css`
     --grampsjs-body-font-size: 17px;
     font-size: var(--grampsjs-body-font-size);
     font-family: var(--grampsjs-body-font-family);
-    --grampsjs-body-font-weight: 330;
+    --grampsjs-body-font-weight: 340;
     font-weight: var(--grampsjs-body-font-weight);
     --mdc-theme-primary: #6d4c41;
     --mdc-theme-on-primary: rgba(255, 255, 255, 0.95);

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -52,7 +52,7 @@ export const sharedStyles = css`
     --md-sys-color-surface-variant: rgb(245 222 215);
     --md-sys-color-on-surface-variant: rgb(83 67 63);
     --md-sys-color-outline: rgb(133 115 110);
-    --md-sys-color-outline-variant: rgb(216 194 187);
+    --md-sys-color-outline-variant: rgb(200 200 200);
     --md-sys-color-shadow: rgb(0 0 0);
     --md-sys-color-scrim: rgb(0 0 0);
     --md-sys-color-inverse-surface: rgb(57 46 43);

--- a/src/appState.js
+++ b/src/appState.js
@@ -11,7 +11,7 @@ export function getInitialAppState() {
   const auth = new Auth()
   return {
     auth,
-    wide: false,
+    screenSize: 'small',
     progress: false,
     settings: getSettings(),
     dbInfo: {},

--- a/src/components/GrampsjsNoteContent.js
+++ b/src/components/GrampsjsNoteContent.js
@@ -23,21 +23,21 @@ export class GrampsjsNoteContent extends LitElement {
           column-gap: 2em;
         }
 
-        .note.frame {
-          border: 1px solid rgba(0, 0, 0, 0.15);
-          border-radius: 8px;
+        .note-container.frame {
+          border: 1px solid var(--md-sys-color-outline-variant);
+          border-radius: 12px;
           padding: 20px 25px;
         }
 
-        .note.frame p {
+        .note-container.frame p {
           margin: 2em 0em;
         }
 
-        .note.frame p:first-child {
+        .note-container.frame p:first-child {
           margin-top: 0;
         }
 
-        .note.frame p:last-child {
+        .note-container.frame p:last-child {
           margin-bottom: 0;
         }
       `,
@@ -59,7 +59,10 @@ export class GrampsjsNoteContent extends LitElement {
 
   render() {
     return html`
-      <div class="note ${this.framed ? 'frame' : ''}" id="note-content"></div>
+      <div class="note-container ${this.framed ? 'frame' : ''}">
+        <div class="note" id="note-content"></div>
+        <slot></slot>
+      </div>
     `
   }
 

--- a/src/components/GrampsjsNoteContent.js
+++ b/src/components/GrampsjsNoteContent.js
@@ -25,7 +25,7 @@ export class GrampsjsNoteContent extends LitElement {
 
         .note-container.frame {
           border: 1px solid var(--md-sys-color-outline-variant);
-          border-radius: 12px;
+          border-radius: 6px;
           padding: 20px 25px;
         }
 

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -2,6 +2,8 @@
 /* eslint-disable no-unused-vars */
 import {LitElement, css, html} from 'lit'
 
+import '@material/web/iconbutton/icon-button.js'
+
 import {sharedStyles} from '../SharedStyles.js'
 import '../views/GrampsjsViewObjectNotes.js'
 import '../views/GrampsjsViewSourceCitations.js'
@@ -13,6 +15,7 @@ import './GrampsjsBreadcrumbs.js'
 import './GrampsjsChildren.js'
 import './GrampsjsCitations.js'
 import './GrampsjsEvents.js'
+import './GrampsjsIcon.js'
 import './GrampsjsNames.js'
 import './GrampsjsPlaceChildren.js'
 import './GrampsjsPlaceRefs.js'
@@ -176,9 +179,6 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
     return [
       sharedStyles,
       css`
-        :host {
-        }
-
         pre {
           max-width: 80%;
           font-size: 11px;
@@ -200,8 +200,6 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
           display: flex;
           flex-direction: column;
           gap: 2rem;
-          width: calc(100% - 235px);
-          padding-right: 35px;
         }
 
         .row {
@@ -213,6 +211,7 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
         .section {
           flex: 1 1 200px;
           scroll-margin-top: 100px;
+          margin-right: 20px;
         }
 
         .sections h3 {
@@ -221,15 +220,6 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
           font-size: 24px;
           padding-bottom: 12px;
           border-bottom: 1px solid var(--md-sys-color-outline-variant);
-        }
-
-        @media (min-width: 768px) {
-          #picture {
-            float: right;
-            text-align: right;
-            margin-left: 40px;
-            margin-right: 0px;
-          }
         }
 
         p.button-list {
@@ -244,12 +234,78 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
         }
 
         div.toc {
-          margin-left: auto;
-          position: sticky;
-          width: 200px;
-          top: 100px;
-          height: fit-content;
-          margin-left: auto;
+          display: none;
+        }
+
+        div.bottom-bar {
+          position: fixed;
+          display: none; /* flex */
+          bottom: 0;
+          right: 0;
+          width: 100%;
+          height: 50px;
+          background-color: white;
+          border-top: 1px solid var(--md-sys-color-outline-variant);
+          box-sizing: border-box;
+        }
+
+        div.bottom-bar-content {
+          position: relative;
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          padding: 10px;
+          justify-content: space-between;
+          box-sizing: border-box;
+        }
+
+        div.bottom-bar-content > * {
+          flex: 1 1 auto;
+          align-items: center;
+          text-align: center;
+        }
+
+        div.bottom-bar-content md-icon-button {
+          --md-icon-button-icon-size: 22px;
+          width: 34px;
+          height: 34px;
+        }
+
+        @media (min-width: 992px) {
+          #picture {
+            float: right;
+            text-align: right;
+            margin-left: 40px;
+            margin-right: 0px;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          div.toc {
+            display: block;
+            margin-left: auto;
+            position: sticky;
+            width: 200px;
+            top: 100px;
+            height: fit-content;
+            margin-left: auto;
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .sections {
+            width: calc(100% - 235px);
+            padding-right: 35px;
+          }
+
+          .row {
+            display: flex;
+            justify-content: space-between;
+          }
+
+          div.bottom-bar {
+            display: none;
+          }
         }
       `,
     ]
@@ -321,6 +377,9 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
         <div class="sections">${this.renderSections()}</div>
         <div class="toc">${this.renderToc()}</div>
       </div>
+      <div class="bottom-bar">
+        <div class="bottom-bar-content"></div>
+      </div>
 
       ${this.dialogContent}
     `
@@ -340,7 +399,7 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
       <grampsjs-object-toc
         .tabs=${visibleTabs}
         .appState="${this.appState}"
-        activeSection=${this._currentVisibleSection}
+        .activeSection="${this._currentVisibleSection}"
         @toc-item-click=${this._handleTocItemClick}
       ></grampsjs-object-toc>
     `

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -50,11 +50,6 @@ const _allTabs = {
       data.family_list?.length > 0 || data.parent_family_list?.length > 0,
     conditionEdit: () => false,
   },
-  names: {
-    title: '_Names',
-    condition: data => 'primary_name' in data,
-    conditionEdit: data => 'primary_name' in data,
-  },
   enclosed: {
     title: 'Place Hierarchy',
     condition: data =>
@@ -106,6 +101,11 @@ const _allTabs = {
     condition: data => data?.media_list?.length > 0,
     conditionEdit: data => 'media_list' in data,
   },
+  names: {
+    title: '_Names',
+    condition: data => 'primary_name' in data,
+    conditionEdit: data => 'primary_name' in data,
+  },
   notes: {
     title: 'Notes',
     condition: data => data?.note_list?.length > 0,
@@ -136,6 +136,14 @@ const _allTabs = {
     title: 'Internet',
     condition: data => data?.urls?.length > 0,
     conditionEdit: data => 'urls' in data,
+  },
+  metadata: {
+    title: 'Metadata',
+    condition: data =>
+      data?.attribute_list?.length > 0 ||
+      data?.urls?.length > 0 ||
+      data?.address_list?.length > 0,
+    conditionEdit: data => 'urls' in data || 'attribute_list' in data,
   },
   associations: {
     title: 'Associations',
@@ -709,19 +717,6 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
             .map(obj => obj.gramps_id)
             .filter(obj => Boolean(obj))}
         ></grampsjs-view-source-citations>`
-      case 'attributes':
-        return html`<grampsjs-attributes
-          hasEdit
-          .appState="${this.appState}"
-          ?edit="${this.edit}"
-          .data=${this.data.attribute_list}
-          attributeCategory="${this._objectsName.toLowerCase()}"
-        ></grampsjs-attributes>`
-      case 'addresses':
-        return html`<grampsjs-addresses
-          .appState="${this.appState}"
-          .data=${this.data.address_list}
-        ></grampsjs-addresses>`
       case 'notes':
         return html` <grampsjs-view-object-notes
           active
@@ -740,13 +735,33 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
           ?edit="${this.edit}"
           ?editRect="${this.appState.permissions.canEdit}"
         ></grampsjs-gallery>`
-      case 'internet':
-        return html`<grampsjs-urls
-          hasEdit
-          .appState="${this.appState}"
-          .data=${this.data.urls}
-          ?edit="${this.edit}"
-        ></grampsjs-urls>`
+      case 'metadata':
+        return html` ${this.data.attribute_list?.length > 0 || this.edit
+            ? html` <h4>${this._('Attributes')}</h4> `
+            : ''}
+          <grampsjs-attributes
+            hasEdit
+            .appState="${this.appState}"
+            ?edit="${this.edit}"
+            .data=${this.data.attribute_list ?? []}
+            attributeCategory="${this._objectsName.toLowerCase()}"
+          ></grampsjs-attributes>
+          ${this.data.address_list?.length > 0
+            ? html`<h4>${this._('Addresses')}</h4>`
+            : ''}
+          <grampsjs-addresses
+            .appState="${this.appState}"
+            .data=${this.data.address_list ?? []}
+          ></grampsjs-addresses>
+          ${this.data.urls?.length || this.edit > 0
+            ? html`<h4>${this._('Internet')}</h4>`
+            : ''}
+          <grampsjs-urls
+            hasEdit
+            .appState="${this.appState}"
+            .data=${this.data.urls ?? []}
+            ?edit="${this.edit}"
+          ></grampsjs-urls>`
       case 'associations':
         return html`<grampsjs-associations
           hasEdit

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -122,21 +122,6 @@ const _allTabs = {
       data?.backlinks?.citation?.length > 0 && 'abbrev' in data,
     conditionEdit: data => false,
   },
-  attributes: {
-    title: 'Attributes',
-    condition: data => data?.attribute_list?.length > 0,
-    conditionEdit: data => 'attribute_list' in data,
-  },
-  addresses: {
-    title: 'Addresses',
-    condition: data => data?.address_list?.length > 0,
-    conditionEdit: data => false, // 'address_list' in data // FIXME editable in principle but UI not implemented
-  },
-  internet: {
-    title: 'Internet',
-    condition: data => data?.urls?.length > 0,
-    conditionEdit: data => 'urls' in data,
-  },
   metadata: {
     title: 'Metadata',
     condition: data =>

--- a/src/components/GrampsjsObjectToc.js
+++ b/src/components/GrampsjsObjectToc.js
@@ -1,0 +1,88 @@
+import {LitElement, html, css} from 'lit'
+import {sharedStyles} from '../SharedStyles.js'
+import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
+
+export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
+  static get styles() {
+    return [
+      sharedStyles,
+      css`
+        md-list.toc-list {
+          --md-list-item-label-text-weight: 400;
+          --md-list-item-label-text-size: 14px;
+          --md-list-item-label-text-color: var(
+            --md-sys-color-on-surface-variant
+          );
+          --md-list-item-hover-state-layer-color: var(--md-sys-color-surface);
+          --md-list-item-top-space: 0px;
+          --md-list-item-bottom-space: 0px;
+          --md-list-item-one-line-container-height: 40px;
+        }
+
+        md-list-item.active {
+          --md-list-item-label-text-weight: 600;
+        }
+      `,
+    ]
+  }
+
+  static get properties() {
+    return {
+      tabs: {type: Object},
+      activeSection: {type: String},
+    }
+  }
+
+  constructor() {
+    super()
+    this.tabs = {}
+    this.activeSection = ''
+  }
+
+  render() {
+    const tabKeys = Object.keys(this.tabs)
+    if (tabKeys.length <= 1) {
+      return html`` // Don't show TOC if there's only one section
+    }
+
+    return html`
+      <md-list class="toc-list">
+        ${tabKeys.map(
+          key => html`
+            <md-list-item
+              type="button"
+              id="toc-item-${key}"
+              class="${key === this.activeSection ? 'active' : ''}"
+              @click="${e => this._handleItemClick(e, key)}"
+            >
+              ${this._(this.tabs[key].title)}
+            </md-list-item>
+          `
+        )}
+      </md-list>
+    `
+  }
+
+  setActiveSection(sectionKey) {
+    this.activeSection = sectionKey
+  }
+
+  _handleItemClick(e, sectionKey) {
+    e.preventDefault()
+    e.stopPropagation()
+
+    this.activeSection = sectionKey
+
+    this.dispatchEvent(
+      new CustomEvent('toc-item-click', {
+        detail: {
+          sectionKey,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    )
+  }
+}
+
+customElements.define('grampsjs-object-toc', GrampsjsObjectToc)

--- a/src/components/GrampsjsObjectToc.js
+++ b/src/components/GrampsjsObjectToc.js
@@ -39,6 +39,7 @@ export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
     return {
       tabs: {type: Object},
       activeSection: {type: String},
+      heading: {type: Boolean},
     }
   }
 
@@ -46,6 +47,7 @@ export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
     super()
     this.tabs = {}
     this.activeSection = ''
+    this.heading = false
   }
 
   render() {
@@ -55,7 +57,7 @@ export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
     }
 
     return html`
-      <h3>${this._('Table Of Contents')}</h3>
+      ${this.heading ? html`<h3>${this._('Table Of Contents')}</h3>` : ''}
       <md-list class="toc-list">
         ${tabKeys.map(
           key => html`

--- a/src/components/GrampsjsObjectToc.js
+++ b/src/components/GrampsjsObjectToc.js
@@ -22,6 +22,15 @@ export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
         md-list-item.active {
           --md-list-item-label-text-weight: 600;
         }
+
+        h3 {
+          margin-left: 14px;
+          margin-bottom: 12px;
+          margin-top: 0;
+          font-size: 16px;
+          font-weight: 420;
+          opacity: 0.55;
+        }
       `,
     ]
   }
@@ -46,6 +55,7 @@ export class GrampsjsObjectToc extends GrampsjsAppStateMixin(LitElement) {
     }
 
     return html`
+      <h3>${this._('Table Of Contents')}</h3>
       <md-list class="toc-list">
         ${tabKeys.map(
           key => html`

--- a/src/strings.js
+++ b/src/strings.js
@@ -567,6 +567,7 @@ export const grampsStrings = [
   'Surname',
   'Surnames',
   'System Information',
+  'Table Of Contents',
   'Tag Report',
   'Tag',
   'Tags',

--- a/src/strings.js
+++ b/src/strings.js
@@ -503,6 +503,7 @@ export const grampsStrings = [
   'Relationship',
   'Relationships',
   'Religion',
+  'Remove note',
   'Report',
   'Repositories',
   'Repository Note',

--- a/src/views/GrampsjsViewObjectNotes.js
+++ b/src/views/GrampsjsViewObjectNotes.js
@@ -1,11 +1,16 @@
 import {html, css} from 'lit'
 
-import '@material/mwc-icon-button'
+import {mdiLinkOff, mdiLinkPlus, mdiPlus} from '@mdi/js'
+
+import '@material/web/button/text-button'
+import '@material/web/iconbutton/icon-button.js'
 
 import {GrampsjsViewObjectsDetail} from './GrampsjsViewObjectsDetail.js'
 import '../components/GrampsjsNoteContent.js'
 import '../components/GrampsjsFormNoteRef.js'
 import '../components/GrampsjsFormNewNote.js'
+import '../components/GrampsjsIcon.js'
+import '../components/GrampsjsTooltip.js'
 import {fireEvent, makeHandle} from '../util.js'
 
 const BASE_DIR = ''
@@ -19,12 +24,33 @@ export class GrampsjsViewObjectNotes extends GrampsjsViewObjectsDetail {
           margin: 0;
         }
 
-        mwc-button {
-          margin-top: 1em;
-          margin-bottom: 2em;
+        div.note-content {
+          padding-top: 1.2em;
+          padding-bottom: 1.2em;
+        }
+
+        div.note-meta {
+          margin-top: 1.2em;
+          display: flex;
+          justify-content: flex-end;
+        }
+
+        div.note-edit-meta {
+          margin-bottom: 1.2em;
         }
       `,
     ]
+  }
+
+  static get properties() {
+    return {
+      numberOfNotes: {type: Number},
+    }
+  }
+
+  constructor() {
+    super()
+    this.numberOfNotes = 0
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -50,22 +76,41 @@ export class GrampsjsViewObjectNotes extends GrampsjsViewObjectsDetail {
   }
 
   renderElements() {
-    return html` ${this._data.map(obj => this.renderNote(obj))} `
+    return html`${this._data.map(obj => this.renderNote(obj))} `
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  renderLoading() {
+    const skeleton =
+      '<p><span class="skeleton" style="width:100%;">&nbsp;</span></p>'
+    const skeletonNotes = Array(this.numberOfNotes)
+      .fill()
+      .map(
+        () => html` <div class="note-content">
+          <grampsjs-note-content
+            framed
+            content="${skeleton}"
+          ></grampsjs-note-content>
+        </div>`
+      )
+    return html`${skeletonNotes}`
   }
 
   renderEdit() {
     return html`
       <div>
-        <mwc-icon-button
-          class="edit"
-          icon="add_link"
-          @click="${this._handleShareClick}"
-        ></mwc-icon-button>
-        <mwc-icon-button
-          class="edit"
-          icon="add"
-          @click="${this._handleAddClick}"
-        ></mwc-icon-button>
+        <md-icon-button class="edit" @click="${this._handleShareClick}">
+          <grampsjs-icon
+            path="${mdiLinkPlus}"
+            color="var(--mdc-theme-secondary)"
+          ></grampsjs-icon>
+        </md-icon-button>
+        <md-icon-button class="edit" @click="${this._handleAddClick}">
+          <grampsjs-icon
+            path="${mdiPlus}"
+            color="var(--mdc-theme-secondary)"
+          ></grampsjs-icon>
+        </md-icon-button>
         ${this.dialogContent}
       </div>
     `
@@ -100,26 +145,45 @@ export class GrampsjsViewObjectNotes extends GrampsjsViewObjectsDetail {
   // eslint-disable-next-line class-methods-use-this
   renderNote(obj) {
     return html`
-      <grampsjs-note-content
-        framed
-        grampsId="${obj.gramps_id}"
-        content="${obj?.formatted?.html || obj?.text?.string}"
-      ></grampsjs-note-content>
-
-      ${this.edit
-        ? html`
-            <mwc-icon-button
-              class="edit"
-              icon="delete"
-              @click="${() => this._handleNoteRefDel(obj.handle)}"
-            ></mwc-icon-button>
-          `
-        : html`<mwc-button
-            outlined
-            label="${this._('Details')}"
-            @click="${() => this._handleButtonClick(obj.gramps_id)}"
-          >
-          </mwc-button>`}
+      <div class="note-content">
+        <grampsjs-note-content
+          framed
+          grampsId="${obj.gramps_id}"
+          content="${obj?.formatted?.html || obj?.text?.string}"
+        >
+          ${this.edit
+            ? ''
+            : html`<div class="note-meta">
+                <md-text-button
+                  outlined
+                  @click="${() => this._handleButtonClick(obj.gramps_id)}"
+                >
+                  ${this._('Details')}
+                </md-text-button>
+              </div>`}
+        </grampsjs-note-content>
+      </div>
+      <div class="note-edit-meta">
+        ${this.edit
+          ? html`
+              <md-icon-button
+                @click="${() => this._handleNoteRefDel(obj.handle)}"
+                id="del-note-${obj.handle}"
+              >
+                <grampsjs-icon
+                  path="${mdiLinkOff}"
+                  class="edit"
+                  color="var(--mdc-theme-secondary)"
+                  icon="delete"
+                ></grampsjs-icon>
+              </md-icon-button>
+              <grampsjs-tooltip
+                for="del-note-${obj.handle}"
+                content="${this._('Remove note')}"
+              ></grampsjs-tooltip>
+            `
+          : ''}
+      </div>
     `
   }
 

--- a/src/views/GrampsjsViewObjectsDetail.js
+++ b/src/views/GrampsjsViewObjectsDetail.js
@@ -36,6 +36,9 @@ export class GrampsjsViewObjectsDetail extends GrampsjsView {
   }
 
   renderContent() {
+    if (this.loading) {
+      return this.renderLoading()
+    }
     if (this._data.length === 0) {
       return html`${this.edit ? this.renderEdit() : ''}`
     }
@@ -43,6 +46,10 @@ export class GrampsjsViewObjectsDetail extends GrampsjsView {
       ${this.edit ? this.renderEdit() : ''} ${this.renderElements()}
       ${this.dialogContent}
     `
+  }
+
+  renderLoading() {
+    return ''
   }
 
   renderEdit() {}

--- a/src/views/GrampsjsViewObjectsDetail.js
+++ b/src/views/GrampsjsViewObjectsDetail.js
@@ -2,6 +2,7 @@
 import {html, css} from 'lit'
 
 import {GrampsjsView} from './GrampsjsView.js'
+import {arrayEqual} from '../util.js'
 
 export class GrampsjsViewObjectsDetail extends GrampsjsView {
   static get styles() {
@@ -61,7 +62,13 @@ export class GrampsjsViewObjectsDetail extends GrampsjsView {
   update(changed) {
     super.update(changed)
     if (this.active && changed.has('grampsIds')) {
-      this._updateData()
+      // grampsIds is an array, so we need to check if its *contents* have changed as well
+      if (
+        changed.get('grampsIds') === undefined ||
+        !arrayEqual(this.grampsIds, changed.get('grampsIds'))
+      ) {
+        this._updateData()
+      }
     }
   }
 


### PR DESCRIPTION
This removes the tabbed structure in all object views. To maintain navigatability, on wide screens a table of contens sidebar is added; on mobile, the TOC is reachable by clicking an icon next to section headers; it opens in a modal.

Fixes #666 :smiling_imp: 