### PR TITLE
Ensure selects overflow when in dialog

### DIFF
--- a/src/components/GrampsjsFormEditCitationDetails.js
+++ b/src/components/GrampsjsFormEditCitationDetails.js
@@ -63,7 +63,11 @@ class GrampsjsFormEditCitationDetails extends GrampsjsObjectForm {
       </p>
 
       <h4 class="label">${this._('Confidence')}</h4>
-      <mwc-select id="select-confidence" @change="${this.handleConfidence}">
+      <mwc-select
+        id="select-confidence"
+        @change="${this.handleConfidence}"
+        fixedMenuPosition
+      >
         ${Object.keys(confidence).map(
           conf => html`
             <mwc-list-item

--- a/src/components/GrampsjsFormNewCitation.js
+++ b/src/components/GrampsjsFormNewCitation.js
@@ -50,7 +50,11 @@ class GrampsjsFormNewCitation extends GrampsjsObjectForm {
       </p>
 
       <h4 class="label">${this._('Confidence')}</h4>
-      <mwc-select id="select-confidence" @change="${this.handleConfidence}">
+      <mwc-select
+        id="select-confidence"
+        @change="${this.handleConfidence}"
+        fixedMenuPosition
+      >
         ${Object.keys(confidence).map(
           conf => html`
             <mwc-list-item

--- a/src/components/GrampsjsFormSelectDate.js
+++ b/src/components/GrampsjsFormSelectDate.js
@@ -86,6 +86,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="select-modifier"
         label="${this._('Type')}"
         @change="${this.handleType}"
+        fixedMenuPosition
       >
         ${Object.keys(modifiers).map(
           modifier => html`
@@ -105,6 +106,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="select-quality"
         label="${this._('Quality')}"
         @change="${this.handleQuality}"
+        fixedMenuPosition
       >
         ${Object.keys(qualifiers).map(
           qualifier => html`
@@ -135,6 +137,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="month1"
         label="${this._('Month')}"
         style="width: 6em;"
+        fixedMenuPosition
       >${[...Array(13).keys()].map(
         idx => html`
           <mwc-list-item
@@ -154,6 +157,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="day1"
         label="${this._('Day')}"
         style="width: 6em;"
+        fixedMenuPosition
       >${[...Array(32).keys()].map(
         idx => html`
           <mwc-list-item
@@ -203,6 +207,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="month2"
         label="${this._('Month')}"
         style="width: 6em;"
+        fixedMenuPosition
       >${[...Array(13).keys()].map(
         idx => html`
           <mwc-list-item
@@ -222,6 +227,7 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         id="day2"
         label="${this._('Day')}"
         style="width: 6em;"
+        fixedMenuPosition
       >${[...Array(32).keys()].map(
         idx => html`
           <mwc-list-item


### PR DESCRIPTION
I noticed select options don't overflow the dialog. I thought it would be a nice visual improvement if they did. 

I think I have updated all the selects that are in dialogs, but not 100% sure

### Before
<img width="1176" height="389" alt="Screenshot 2025-08-06 at 22 32 04" src="https://github.com/user-attachments/assets/6616a8a1-f69c-4685-becf-87c88c6e1ea5" />

### After 
<img width="1190" height="375" alt="Screenshot 2025-08-06 at 22 31 37" src="https://github.com/user-attachments/assets/ea298abc-5693-4fb8-952f-e4144e9ca018" />
