### PR TITLE
Place names: add translation strings and fix date display

### DIFF
--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -593,8 +593,10 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
       case 'placeNames':
         return html` ${this.data.alt_names?.length > 0
           ? html` <grampsjs-place-names
+              .appState="${this.appState}"
               .strings="${this.strings}"
               .data="${this.data.alt_names}"
+              .profile="${this.data.profile.alternate_place_names ?? []}"
               ?edit=${false}
             ></grampsjs-place-names>`
           : ''}`

--- a/src/components/GrampsjsPlaceNames.js
+++ b/src/components/GrampsjsPlaceNames.js
@@ -8,19 +8,31 @@ import {dateIsEmpty} from '../util.js'
 import {GrampsjsEditableTable} from './GrampsjsEditableTable.js'
 
 export class GrampsjsPlaceNames extends GrampsjsEditableTable {
+  static get properties() {
+    return {
+      profile: {type: Array},
+    }
+  }
+
   constructor() {
     super()
     this.objType = 'PlaceName'
     this._columns = ['Name', 'Date', '']
     this.dialogContent = ''
     this.edit = false
+    this.profile = []
   }
 
   row(obj, i, arr) {
+    const objProfile = this.profile?.[i]
     return html`
       <tr>
         <td>${obj.value}</td>
-        <td>${dateIsEmpty(obj.date) ? '' : toDate(obj.date?.dateval)}</td>
+        <td>
+          ${dateIsEmpty(obj.date)
+            ? ''
+            : objProfile?.date_str ?? toDate(obj.date?.dateval)}
+        </td>
         <td>
           ${false // ${this.edit TODO: implement place name edit
             ? this._renderActionBtns(obj.ref, i === 0, i === arr.length - 1)


### PR DESCRIPTION
@cajturner I noticed two issues with #566: frontend strings were not passed to the component and the new `alternate_place_names` profile value from the backend wasn't used, so the date display was still wrong. Both is fixed in this PR; you should be able to rebase #713 onto this once merged.