### PR TITLE
Lazy loading of updated data in views

### DIFF
--- a/src/components/GrampsjsConnectedComponent.js
+++ b/src/components/GrampsjsConnectedComponent.js
@@ -6,11 +6,12 @@ Base class for Components that fetch data when first loaded
 import {LitElement} from 'lit'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 import {sharedStyles} from '../SharedStyles.js'
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
 
 import {fireEvent} from '../util.js'
 
-export class GrampsjsConnectedComponent extends GrampsjsAppStateMixin(
-  LitElement
+export class GrampsjsConnectedComponent extends GrampsjsStaleDataMixin(
+  GrampsjsAppStateMixin(LitElement)
 ) {
   static get styles() {
     return [sharedStyles]
@@ -39,11 +40,15 @@ export class GrampsjsConnectedComponent extends GrampsjsAppStateMixin(
     this._errorMessage = ''
     this._data = {}
     this._oldUrl = ''
-    this._boundUpdateData = this._updateData.bind(this)
     this._boundsHandleOnline = this._handleOnline.bind(this)
     this.method = 'GET'
     this.postData = {}
     this._oldPostData = {}
+  }
+
+  get active() {
+    // this is needed for the StaleDataMixin
+    return true
   }
 
   render() {
@@ -144,15 +149,18 @@ export class GrampsjsConnectedComponent extends GrampsjsAppStateMixin(
     }
   }
 
+  handleUpdateStaleData() {
+    // reload with 1 second delay so the views are prioritized
+    setTimeout(() => this._updateData(), 1000)
+  }
+
   connectedCallback() {
     super.connectedCallback()
-    window.addEventListener('db:changed', this._boundUpdateData)
     window.addEventListener('online', this._boundHandleOnline)
   }
 
   disconnectedCallback() {
     window.removeEventListener('online', this._boundHandleOnline)
-    window.removeEventListener('db:changed', this._boundUpdateData)
     super.disconnectedCallback()
   }
 }

--- a/src/mixins/GrampsjsStaleDataMixin.js
+++ b/src/mixins/GrampsjsStaleDataMixin.js
@@ -1,0 +1,49 @@
+/* Mixing for views that need to handle stale data lazily.
+ * This mixin listens for database changes and marks the data as stale.
+ * When the view becomes active, it fetches the latest data.
+ */
+export const GrampsjsStaleDataMixin = superClass =>
+  class extends superClass {
+    static get properties() {
+      return {
+        _isStale: {type: Boolean, attribute: false},
+      }
+    }
+
+    constructor() {
+      super()
+      this._isStale = false
+      this._boundHandleDbChanged = this._handleDbChanged.bind(this)
+    }
+
+    connectedCallback() {
+      super.connectedCallback()
+      window.addEventListener('db:changed', this._boundHandleDbChanged)
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback()
+      window.removeEventListener('db:changed', this._boundHandleDbChanged)
+    }
+
+    _handleDbChanged() {
+      if (this.active) {
+        this._handleUpdateStaleData()
+      } else {
+        this._isStale = true
+      }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    _handleUpdateStaleData() {
+      // implement in subclass
+    }
+
+    update(changed) {
+      super.update(changed)
+      if (changed.has('active') && this.active && this._isStale) {
+        this._handleUpdateStaleData()
+        this._isStale = false
+      }
+    }
+  }

--- a/src/mixins/GrampsjsStaleDataMixin.js
+++ b/src/mixins/GrampsjsStaleDataMixin.js
@@ -28,21 +28,21 @@ export const GrampsjsStaleDataMixin = superClass =>
 
     _handleDbChanged() {
       if (this.active) {
-        this._handleUpdateStaleData()
+        this.handleUpdateStaleData()
       } else {
         this._isStale = true
       }
     }
 
     // eslint-disable-next-line class-methods-use-this
-    _handleUpdateStaleData() {
+    handleUpdateStaleData() {
       // implement in subclass
     }
 
     update(changed) {
       super.update(changed)
       if (changed.has('active') && this.active && this._isStale) {
-        this._handleUpdateStaleData()
+        this.handleUpdateStaleData()
         this._isStale = false
       }
     }

--- a/src/views/GrampsjsViewBlog.js
+++ b/src/views/GrampsjsViewBlog.js
@@ -3,9 +3,11 @@ import {css, html} from 'lit'
 import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsBlogPostPreview.js'
 
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
+
 import {fireEvent, clickKeyHandler} from '../util.js'
 
-export class GrampsjsViewBlog extends GrampsjsView {
+export class GrampsjsViewBlog extends GrampsjsStaleDataMixin(GrampsjsView) {
   static get styles() {
     return [
       super.styles,
@@ -135,6 +137,10 @@ export class GrampsjsViewBlog extends GrampsjsView {
 
   _handlePreviewClick(grampsId) {
     fireEvent(this, 'nav', {path: `blog/${grampsId}`})
+  }
+
+  _handleUpdateStaleData() {
+    this._fetchData()
   }
 
   async _fetchData() {

--- a/src/views/GrampsjsViewBlog.js
+++ b/src/views/GrampsjsViewBlog.js
@@ -139,7 +139,7 @@ export class GrampsjsViewBlog extends GrampsjsStaleDataMixin(GrampsjsView) {
     fireEvent(this, 'nav', {path: `blog/${grampsId}`})
   }
 
-  _handleUpdateStaleData() {
+  handleUpdateStaleData() {
     this._fetchData()
   }
 

--- a/src/views/GrampsjsViewDashboard.js
+++ b/src/views/GrampsjsViewDashboard.js
@@ -121,7 +121,6 @@ export class GrampsjsViewDashboard extends GrampsjsView {
       <div class="column">
         <div>
           <grampsjs-view-recent-blog-posts
-            ?active=${this.active}
             id="recent-blog"
             .appState="${this.appState}"
           >

--- a/src/views/GrampsjsViewDnaMatches.js
+++ b/src/views/GrampsjsViewDnaMatches.js
@@ -12,9 +12,13 @@ import '../components/GrampsjsFormNewMatch.js'
 import '../components/GrampsjsChromosomeBrowser.js'
 import '../components/GrampsjsBreadcrumbs.js'
 
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
+
 import {fireEvent, personDisplayName} from '../util.js'
 
-export class GrampsjsViewDnaMatches extends GrampsjsView {
+export class GrampsjsViewDnaMatches extends GrampsjsStaleDataMixin(
+  GrampsjsView
+) {
   static get styles() {
     return [
       super.styles,
@@ -476,9 +480,12 @@ export class GrampsjsViewDnaMatches extends GrampsjsView {
     this.edit = false
   }
 
+  handleUpdateStaleData() {
+    this._fetchAllData()
+  }
+
   connectedCallback() {
     super.connectedCallback()
-    window.addEventListener('db:changed', () => this._fetchAllData())
     window.addEventListener('edit-mode:delete', () => this._deleteMatch())
     window.addEventListener('edit-mode:off', () => this._disableEditMode())
   }

--- a/src/views/GrampsjsViewMap.js
+++ b/src/views/GrampsjsViewMap.js
@@ -1,5 +1,6 @@
 /* eslint-disable lit/attribute-value-entities */
 import {html, css} from 'lit'
+import '@material/mwc-textfield'
 
 import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsMap.js'
@@ -9,7 +10,7 @@ import '../components/GrampsjsMapTimeSlider.js'
 import '../components/GrampsjsPlaceBox.js'
 import {getMediaUrl} from '../api.js'
 import {isDateBetweenYears, getGregorianYears} from '../util.js'
-import '@material/mwc-textfield'
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
 
 // This is used for initial map center in absence of places
 const languageCoordinates = {
@@ -56,7 +57,7 @@ const languageCoordinates = {
   ko: [38, 128], // Korean - Approximate center of Korea
 }
 
-export class GrampsjsViewMap extends GrampsjsView {
+export class GrampsjsViewMap extends GrampsjsStaleDataMixin(GrampsjsView) {
   static get styles() {
     return [
       super.styles,
@@ -525,9 +526,8 @@ export class GrampsjsViewMap extends GrampsjsView {
     return [x, y]
   }
 
-  connectedCallback() {
-    super.connectedCallback()
-    window.addEventListener('db:changed', () => this._fetchDataAll())
+  handleUpdateStaleData() {
+    this._fetchDataAll()
   }
 }
 

--- a/src/views/GrampsjsViewObjectsBase.js
+++ b/src/views/GrampsjsViewObjectsBase.js
@@ -14,11 +14,14 @@ import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsPagination.js'
 import '../components/GrampsjsFilterChip.js'
 import '../components/GrampsjsFilters.js'
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
 
 import {fireEvent} from '../util.js'
 import {renderIcon} from '../icons.js'
 
-export class GrampsjsViewObjectsBase extends GrampsjsView {
+export class GrampsjsViewObjectsBase extends GrampsjsStaleDataMixin(
+  GrampsjsView
+) {
   static get styles() {
     return [
       super.styles,
@@ -312,6 +315,10 @@ export class GrampsjsViewObjectsBase extends GrampsjsView {
     if (this._fullUrl !== this._oldUrl) {
       this._fetchData()
     }
+  }
+
+  _handleUpdateStaleData() {
+    this._fetchData()
   }
 
   _fetchData() {

--- a/src/views/GrampsjsViewObjectsBase.js
+++ b/src/views/GrampsjsViewObjectsBase.js
@@ -317,7 +317,7 @@ export class GrampsjsViewObjectsBase extends GrampsjsStaleDataMixin(
     }
   }
 
-  _handleUpdateStaleData() {
+  handleUpdateStaleData() {
     this._fetchData()
   }
 

--- a/src/views/GrampsjsViewRevisions.js
+++ b/src/views/GrampsjsViewRevisions.js
@@ -46,6 +46,8 @@ import '../components/GrampsjsTimedelta.js'
 
 import {GrampsjsView} from './GrampsjsView.js'
 
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
+
 import {renderIconSvg} from '../icons.js'
 
 const changeIcons = {
@@ -81,7 +83,9 @@ const changeIcons = {
   Media_2: mdiImageMinus,
 }
 
-export class GrampsjsViewRevisions extends GrampsjsView {
+export class GrampsjsViewRevisions extends GrampsjsStaleDataMixin(
+  GrampsjsView
+) {
   static get styles() {
     return [
       super.styles,
@@ -240,16 +244,15 @@ export class GrampsjsViewRevisions extends GrampsjsView {
     this._fetchData()
   }
 
+  handleUpdateStaleData() {
+    this._fetchData()
+  }
+
   update(changed) {
     super.update(changed)
     if (changed.has('_page') && changed._page !== this._page) {
       this._fetchData()
     }
-  }
-
-  connectedCallback() {
-    super.connectedCallback()
-    window.addEventListener('db:changed', () => this._fetchData())
   }
 }
 

--- a/src/views/GrampsjsViewTasks.js
+++ b/src/views/GrampsjsViewTasks.js
@@ -2,10 +2,11 @@ import {css, html} from 'lit'
 
 import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsTasks.js'
+import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
 
 import {fireEvent} from '../util.js'
 
-export class GrampsjsViewTasks extends GrampsjsView {
+export class GrampsjsViewTasks extends GrampsjsStaleDataMixin(GrampsjsView) {
   static get styles() {
     return [
       super.styles,
@@ -30,7 +31,6 @@ export class GrampsjsViewTasks extends GrampsjsView {
     super()
     this._data = []
     this._filters = []
-    this._boundFetchData = this._fetchData.bind(this)
   }
 
   render() {
@@ -132,14 +132,8 @@ export class GrampsjsViewTasks extends GrampsjsView {
     }
   }
 
-  connectedCallback() {
-    super.connectedCallback()
-    window.addEventListener('db:changed', this._boundFetchData)
-  }
-
-  disconnectedCallback() {
-    window.removeEventListener('db:changed', this._boundFetchData)
-    super.disconnectedCallback()
+  handleUpdateStaleData() {
+    this._fetchData()
   }
 }
 


### PR DESCRIPTION
This changes the behaviour of views when the database is updated. Rather than reloading data eagerly, it loads them lazily when the view becomes visible. This reduces the number of API requests on every change, which should also make changes feel much faster (and reduce problems such as the one mentioned in #718).

Also fixes #565.