### PR TITLE
Use latest event year for OHM layer in place view map (fixes #467)

### DIFF
--- a/src/components/GrampsjsFormEditLatLong.js
+++ b/src/components/GrampsjsFormEditLatLong.js
@@ -115,7 +115,6 @@ class GrampsjsFormEditLatLong extends GrampsjsObjectForm {
           .appState="${this.appState}"
           latitude="${this.data.lat ? parseFloat(this.data.lat) : 0}"
           longitude="${this.data.long ? parseFloat(this.data.long) : 0}"
-          layerSwitcher
           mapid="edit-latlong-map"
           id="map"
           @mapclick="${this._handleMapClick}"

--- a/src/components/GrampsjsFormEditMapLayer.js
+++ b/src/components/GrampsjsFormEditMapLayer.js
@@ -149,7 +149,6 @@ class GrampsjsFormEditMapLayer extends GrampsjsObjectForm {
           : this._getLongCenter()
       }"
       zoom="${this._getZoom()}"
-      layerSwitcher
       mapid="media-map"
       id="map"
       @mapclick="${this._handleMapClick}"

--- a/src/components/GrampsjsMap.js
+++ b/src/components/GrampsjsMap.js
@@ -37,6 +37,14 @@ class GrampsjsMap extends GrampsjsAppStateMixin(LitElement) {
         <div id="${this.mapid}" style="z-index: 0; width: 100%; height: 100%;">
           <slot> </slot>
         </div>
+        ${this.layerSwitcher ? this._renderLayerSwitcher() : html`<div></div>`}
+      </div>
+    `
+  }
+
+  _renderLayerSwitcher() {
+    return html`
+      <div class="map-layerswitcher">
         <grampsjs-map-layer-switcher
           .appState="${this.appState}"
           .overlays="${this.overlays}"
@@ -62,6 +70,7 @@ class GrampsjsMap extends GrampsjsAppStateMixin(LitElement) {
       longMin: {type: Number},
       longMax: {type: Number},
       overlays: {type: Array},
+      layerSwitcher: {type: Boolean},
       _map: {type: Object},
       _currentStyle: {type: String},
     }
@@ -81,6 +90,7 @@ class GrampsjsMap extends GrampsjsAppStateMixin(LitElement) {
     this.longMin = 0
     this.longMax = 0
     this.overlays = []
+    this.layerSwitcher = false
     this._currentStyle = 'base'
   }
 

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -176,6 +176,20 @@ const zoomByPlaceType = {
   Number: 19,
 }
 
+/* Get the latest event year from the place's events, or return the current year if none exist */
+const getPlaceLatestEventYear = data => {
+  const currentYear = new Date().getFullYear()
+  if (!data?.extended?.backlinks?.event?.length) {
+    return currentYear
+  }
+  return data.extended.backlinks.event.reduce((max, event) => {
+    if (event.date?.year && event.date.year > max) {
+      return event.date.year
+    }
+    return max
+  }, -1)
+}
+
 export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
   static get styles() {
     return [
@@ -643,6 +657,7 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
                   ? zoomByPlaceType[this.data.place_type]
                   : 13}"
                 layerSwitcher
+                year="${getPlaceLatestEventYear(this.data) ?? -1}"
                 mapid="place-map"
                 id="map"
               >
@@ -664,7 +679,6 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
                 zoom="${this._getZoomFromBounds(
                   JSON.parse(mapBounds[0].value)
                 )}"
-                layerSwitcher
                 mapid="media-map"
                 id="map"
               >


### PR DESCRIPTION
- Removed layer switcher form `GrampsjsEditLatLong` and GrampsjsFormEditMapLayer`
- Add back `layerSwitcher` property on `GrampsjsMap` (this was accidentally removed in the last refactoring)
- Compute year of latest event for each place and use that for the OHM layer