### PR TITLE
Add color for mwc-icon-button in meta slot

### DIFF
--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -372,4 +372,8 @@ export const sharedStyles = css`
       font-size: 18px;
     }
   }
+
+  mwc-icon-button[slot='meta'] {
+    color: var(--grampsjs-color-icon);
+  }
 `


### PR DESCRIPTION
This pull request fixes an issue where the Edit button for the main person was not visible in dark mode (the icon appeared black instead of white).
The problem was caused by Material Design’s default styles not adapting to our dark mode theme.

I added a style for mwc-icon-button[slot='meta'] in the shared styles, so the icon color is now controlled by our own CSS variable.
This ensures the button remains visible in dark mode and is consistent with our theme.

I’m not a CSS expert, but this solution works for our use case and overrides the Material Design style that did not support our dark mode.

Before:
<img width="1392" height="334" alt="image" src="https://github.com/user-attachments/assets/371bc5af-203f-4671-b8d3-6c790e16bff6" />

After:
<img width="1382" height="336" alt="image" src="https://github.com/user-attachments/assets/ad46789f-46d4-46ff-a09e-b5a0dd3fa565" />


