### PR TITLE
Ensure login form is less than `90vw`

### DIFF
--- a/src/components/GrampsjsLogin.js
+++ b/src/components/GrampsjsLogin.js
@@ -32,6 +32,8 @@ class GrampsjsLogin extends GrampsjsAppStateMixin(LitElement) {
         }
 
         #login-form {
+          margin: auto;
+          max-width: 90vw;
           position: relative;
           top: 20vh;
         }


### PR DESCRIPTION
This ensures that the login form displays correctly on mobile. Added `margin: auto` to ensure the form is centered.

Closes https://github.com/gramps-project/gramps-web/issues/811