### PR TITLE
Display the assigned time period in the place hierarchy view

### DIFF
--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -621,7 +621,7 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
               <grampsjs-place-refs
                 .appState="${this.appState}"
                 .data="${this.data?.placeref_list}"
-                .profile="${this.data?.profile.direct_parent_places || []}"
+                .profile="${this.data?.profile?.direct_parent_places ?? []}"
                 ?edit="${this.edit}"
               ></grampsjs-place-refs>
             `

--- a/src/components/GrampsjsPlaceRefs.js
+++ b/src/components/GrampsjsPlaceRefs.js
@@ -26,12 +26,13 @@ export class GrampsjsPlaceRefs extends GrampsjsEditableTable {
   }
 
   row(obj, i, arr) {
-    const prof = this.places.length > i ? this.profile[i] : {}
+    const placeProf = this.places.length > i ? this.places[i].profile : {}
+    const placeRefProf = this.profile.length > i ? this.profile[i] : {}
     return html`
-      <tr @click=${() => this._handleClick(prof.place?.gramps_id)}>
-        <td>${prof.place?.name}</td>
-        <td>${prof.place?.type}</td>
-        <td>${prof.date_str}</td>
+      <tr @click=${() => this._handleClick(placeProf.gramps_id)}>
+        <td>${placeProf.name}</td>
+        <td>${placeProf.type}</td>
+        <td>${placeRefProf.date_str}</td>
         <td>
           ${this.edit
             ? this._renderActionBtns(


### PR DESCRIPTION
This PR belongs to the issue #748.

It allows the user to view the corresponding dates of each direct parent place.
<img width="600" height="315" alt="image" src="https://github.com/user-attachments/assets/b000395e-9cd3-4520-b91a-7aa99dd4cb1b" />


This feature based on the API changes in the place profile, [here](https://github.com/gramps-project/gramps-web-api/pull/707). 