### PR TITLE
Add support for hiding DNA in navigation

### DIFF
--- a/src/components/GrampsjsMainMenu.js
+++ b/src/components/GrampsjsMainMenu.js
@@ -123,27 +123,31 @@ class GrampsjsAppBar extends GrampsjsAppStateMixin(LitElement) {
           ></mwc-icon
         >
       </grampsjs-list-item>
-      <grampsjs-list-item
-        href="${BASE_DIR}/dna-matches"
-        graphic="icon"
-        ?selected="${['dna-matches', 'dna-chromosome', 'ydna'].includes(
-          this.appState.path.page
-        )}"
-      >
-        <span>${this._('DNA')}</span>
-        <mwc-icon slot="graphic"
-          ><span class="raise"
-            >${renderIcon(
-              mdiDna,
-              ['dna-matches', 'dna-chromosome', 'ydna'].includes(
+      ${this.appState.frontendConfig.hideDNALink
+        ? ''
+        : html`
+            <grampsjs-list-item
+              href="${BASE_DIR}/dna-matches"
+              graphic="icon"
+              ?selected="${['dna-matches', 'dna-chromosome', 'ydna'].includes(
                 this.appState.path.page
-              )
-                ? selectedColor
-                : defaultColor
-            )}</span
-          ></mwc-icon
-        >
-      </grampsjs-list-item>
+              )}"
+            >
+              <span>${this._('DNA')}</span>
+              <mwc-icon slot="graphic"
+                ><span class="raise"
+                  >${renderIcon(
+                    mdiDna,
+                    ['dna-matches', 'dna-chromosome', 'ydna'].includes(
+                      this.appState.path.page
+                    )
+                      ? selectedColor
+                      : defaultColor
+                  )}</span
+                ></mwc-icon
+              >
+            </grampsjs-list-item>
+          `}
       ${this.canUseChat
         ? html`
             <grampsjs-list-item


### PR DESCRIPTION
This adds support for a new `hideDNALink` option in the frontend config in order to hide DNA.

This is only cosmetic, and DNA will still be accessible via the relevant routes.

Closes #630