### PR TITLE
fix color for mwc-icon-button in meta slot

### DIFF
--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -374,6 +374,6 @@ export const sharedStyles = css`
   }
 
   mwc-icon-button[slot='meta'] {
-    color: var(--grampsjs-color-icon);
+    color: var(--grampsjs-color-icon-default);
   }
 `


### PR DESCRIPTION
This PR fixes the issue [here](https://github.com/gramps-project/gramps-web/pull/818).
Now light and darkmode should work properly.