### PR TITLE
Customize search icon color for dark mode support

### DIFF
--- a/src/views/GrampsjsViewSearch.js
+++ b/src/views/GrampsjsViewSearch.js
@@ -207,6 +207,14 @@ export class GrampsjsViewSearch extends GrampsjsView {
     }
   }
 
+  _customizeSearchIcon() {
+    const textfield = this.shadowRoot.getElementById('search-field')
+    const icon = textfield.shadowRoot.querySelector('.mdc-text-field__icon')
+    if (icon) {
+      icon.style.color = 'var(--grampsjs-body-font-color-50)'
+    }
+  }
+
   _unfocus() {
     if (this.active) {
       const el = this.shadowRoot.getElementById('search-field')
@@ -242,6 +250,7 @@ export class GrampsjsViewSearch extends GrampsjsView {
       this.loading = true
       this._executeSearch(this._page)
     }
+    this._customizeSearchIcon()
   }
 
   _handleSearchKey(event) {


### PR DESCRIPTION
Currently, the search icon in the search bar is not displayed correctly in dark mode:
<img width="800" height="220" alt="image" src="https://github.com/user-attachments/assets/704cb5f9-702d-4c01-a49a-4aefe384e704" />

This PR fixes this issue, by modifying the icon child inside of the `<mwc-textfield>` component:
<img width="800" height="220" alt="image" src="https://github.com/user-attachments/assets/ba54f03e-8ca4-4374-a017-9521d0ac25b0" />

To be honest, I don't like this solution, but as far as I know, this is the only way to change the icon color of an `<mwc-textfield>` element. An alternative approach would be to remove the icon completely or use a different component.
