### PR TITLE
Bugfix for #909: GrampsjsFormSelectType in New-Dialogs did not reset its previous value

### DIFF
--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -65,6 +65,7 @@ class GrampsjsFormSelectType extends GrampsjsAppStateMixin(LitElement) {
   reset() {
     this._hasCustomType = false
     this._touched = false
+    this.value = ''
     const selectElement = this.renderRoot.querySelector('#select-type')
     if (selectElement) {
       selectElement.select(this.defaultValue)


### PR DESCRIPTION
... when opening the New-Dialog again.