### PR TITLE
Handle keyboard shortcuts in editor

### DIFF
--- a/src/components/GrampsjsEditor.js
+++ b/src/components/GrampsjsEditor.js
@@ -212,6 +212,7 @@ class GrampsjsEditor extends GrampsjsAppStateMixin(LitElement) {
         contenteditable="true"
         @beforeinput="${this._handleBeforeInput}"
         @compositionend="${this._handleCompositionEnd}"
+        @keydown="${this._handleKeydown}"
         .innerHTML="${live(this._html)}"
       ></div>
       ${this._renderLinkDialog()}
@@ -228,8 +229,42 @@ class GrampsjsEditor extends GrampsjsAppStateMixin(LitElement) {
     return this.renderRoot.getElementById('editor-content')
   }
 
-  // handle input actions by modifying the data object
-  // (and cancelling the browser default behaviour)
+  _handleKeydown(e) {
+    if (e.key === 'Escape') {
+      this._editorDiv.blur()
+      e.preventDefault()
+      e.stopPropagation()
+      return
+    }
+    if (e.ctrlKey || e.metaKey) {
+      let handled = false
+      switch (e.key.toLowerCase()) {
+        case 'b':
+          this._handleFormat('bold')
+          handled = true
+          break
+        case 'i':
+          this._handleFormat('italic')
+          handled = true
+          break
+        case 'u':
+          this._handleFormat('underline')
+          handled = true
+          break
+        case 'k':
+          this._handleFormat('link')
+          handled = true
+          break
+        default:
+          break
+      }
+      if (handled) {
+        e.preventDefault()
+        e.stopPropagation()
+      }
+    }
+  }
+
   _handleBeforeInput(e) {
     e.preventDefault()
     e.stopPropagation()


### PR DESCRIPTION
[AI generated summary]

This pull request adds keyboard shortcut support to the `GrampsjsEditor` component, enhancing the user experience by allowing formatting actions and blur behavior via keyboard input.

**Keyboard shortcut enhancements:**

* Added a `keydown` event listener to the editor's main `div` to enable keyboard shortcuts for formatting (Ctrl/Cmd+B for bold, Ctrl/Cmd+I for italic, Ctrl/Cmd+U for underline, Ctrl/Cmd+K for link) and to allow the Escape key to blur the editor.

Fixes #893.