### PR TITLE
Select fields sometimes not wide enough even if there is enough space

### DIFF
--- a/src/components/GrampsjsFormSelectObject.js
+++ b/src/components/GrampsjsFormSelectObject.js
@@ -35,7 +35,9 @@ class GrampsjsFormSelectObject extends GrampsjsAppStateMixin(LitElement) {
       css`
         mwc-menu {
           --mdc-menu-min-width: 200px;
-          --mdc-menu-max-width: 400px;
+          // .cca: Increase width of Source selection dropdown (increase to width of other dropdowns accepted.)
+          --mdc-menu-min-width: 600px;
+          //--mdc-menu-max-width: 400px;
         }
 
         .container {


### PR DESCRIPTION
Increase mdc-menu-min-width to 600px.
ref: #891