### PR TITLE
Fix missing replace media button for non image media (#951)

### DIFF
--- a/src/components/GrampsjsMediaObject.js
+++ b/src/components/GrampsjsMediaObject.js
@@ -239,6 +239,12 @@ export class GrampsjsMediaObject extends GrampsjsObject {
             )}
       </grampsjs-rect-container>
 
+      ${this._renderReplaceFile()}
+    `
+  }
+
+  _renderReplaceFile() {
+    return html`
       <p>
         <grampsjs-form-upload
           @formdata:changed="${this._handleFormData}"
@@ -272,6 +278,8 @@ export class GrampsjsMediaObject extends GrampsjsObject {
         mime="${this.data.mime}"
         @click=${this._handleClick}
       ></grampsjs-img>
+
+      ${this.edit ? this._renderReplaceFile() : ''}
     `
   }
 


### PR DESCRIPTION
When editing a media object, the `Replace file" button was available only for images. This fixes #951 and allows to replace any file type. 