### PR TITLE
Display source citations from associated events along with direct citations

### DIFF
--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -119,7 +119,11 @@ const _allTabs = {
   },
   sourceCitations: {
     title: 'Sources',
-    condition: data => data?.citation_list?.length > 0,
+    condition: data =>
+      data?.citation_list?.length > 0 ||
+      (data?.extended?.events || []).some(
+        event => (event.citation_list || []).length > 0
+      ),
     conditionEdit: data => 'citation_list' in data,
   },
   citations: {
@@ -738,15 +742,28 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
           .profile=${this.data?.profile?.children}
           ?edit="${this.edit}"
         ></grampsjs-children>`
-      case 'sourceCitations':
+      case 'sourceCitations': {
+        const directCitations = (this.data?.extended?.citations || [])
+          .map(obj => obj.handle)
+          .filter(obj => Boolean(obj))
+        let citationIds = directCitations
+
+        // In edit mode, only show direct citations (which are editable)
+        // In view mode, combine with event citations
+        if (!this.edit) {
+          const eventCitations = (this.data?.extended?.events || [])
+            .flatMap(obj => obj.citation_list || [])
+            .filter(obj => Boolean(obj))
+          citationIds = [...new Set([...directCitations, ...eventCitations])]
+        }
+
         return html`<grampsjs-view-source-citations
           active
           .appState="${this.appState}"
           ?edit="${this.edit}"
-          .grampsIds=${(this.data?.extended?.citations || [])
-            .map(obj => obj.gramps_id)
-            .filter(obj => Boolean(obj))}
+          .grampsIds=${citationIds}
         ></grampsjs-view-source-citations>`
+      }
       case 'notes':
         return html` <grampsjs-view-object-notes
           active

--- a/src/views/GrampsjsViewSourceCitations.js
+++ b/src/views/GrampsjsViewSourceCitations.js
@@ -19,16 +19,11 @@ export class GrampsjsViewSourceCitations extends GrampsjsViewObjectsDetail {
 
   // eslint-disable-next-line class-methods-use-this
   getUrl() {
-    const rules = {
-      function: 'or',
-      rules: this.grampsIds.map(grampsId => ({
-        name: 'HasIdOf',
-        values: [grampsId],
-      })),
-    }
+    const gql = (this.grampsIds || []).map(h => `handle="${h}"`).join(' or ')
+
     return `/api/citations/?locale=${
       this.appState.i18n.lang || 'en'
-    }&profile=all&extend=all&rules=${encodeURIComponent(JSON.stringify(rules))}`
+    }&profile=all&extend=all&gql=${encodeURIComponent(gql)}`
   }
 
   renderElements() {


### PR DESCRIPTION
### Desired feature

Currently the Sources tab of an object only displays direct citations attached to the object itself (citation_list).

However, many sources are attached to events associated with the object (e.g. birth, death, marriage). In those cases, the Sources tab appears empty even though the object has citations through its events.

This makes it difficult for users to quickly see and access all sources relevant to an object.

### Proposed Solution

This change makes the Sources tab also display citations coming from associated events, in addition to direct citations.

The behavior differs slightly between view and edit modes:
- In View mode displays both direct citations and citations attached to associated events
- In Edit mode displays only direct citations, since event citations cannot be edited from this view

### Implementation

1. Show the Sources tab when event citations exist
The tab visibility condition now also checks whether any associated event contains citations:
```javascript
(data?.extended?.events || []).some(
  event => (event.citation_list || []).length > 0
)
```
2. Get citations list
Direct and events citations are both available from the data object. But for events citation, we only have the handle instead of the gramps_id.

Direct citations are retrieved from:
```javascript
data.extended.citations
```

Event citations are retrieved from:
```javascript
data.extended.events[].citation_list
```

In view mode the two lists are merged and deduplicated using a Set.

3. Fetch citations using gql
Previously citations were fetched using the HasIdOf filter rule, which requires gramps_id.

Since event citations only provide handles, the request now uses the gql query parameter to filter citations by handle:
```javascript
handle="H1" or handle="H2" ...
```

### Result

The Sources tab now displays all citations associated with an object, including those attached to events. This implementation does not allow to distinguish if citations are directly attached to the object or coming from events. This is fine for my needs, but tell me if I need to find a way to improve this.