### PR TITLE
Migrate mwc-fab to md-fab

### DIFF
--- a/global.css
+++ b/global.css
@@ -8,6 +8,7 @@ body {
 
 :root {
   color: var(--md-sys-color-on-surface);
+  --md-fab-secondary-container-color: var(--mdc-theme-secondary);
   --color-boy: #64b5f6;
   --color-girl: #ef9a9a;
   --mdc-theme-primary: var(--md-sys-color-primary);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@material/mwc-circular-progress": "^0.27.0",
         "@material/mwc-dialog": "^0.27.0",
         "@material/mwc-drawer": "^0.27.0",
-        "@material/mwc-fab": "^0.27.0",
         "@material/mwc-formfield": "^0.27.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-icon-button": "^0.27.0",
@@ -3112,52 +3111,6 @@
       }
     },
     "node_modules/@material/mwc-drawer/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/@material/mwc-fab": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-fab/-/mwc-fab-0.27.0.tgz",
-      "integrity": "sha512-7XUxeO14etuXe0FQdB1Y6bg8TilbQKX/NGi9b0O6D0hkcY3Y0Vk2xyoAvQArbHRz3hGfiH1cS7FaJGRSilWcjg==",
-      "dependencies": {
-        "@material/mwc-ripple": "^0.27.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-fab/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-fab/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-fab/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-fab/node_modules/lit-html": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
       "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
@@ -16577,54 +16530,6 @@
         "lit": "^2.0.0",
         "tslib": "^2.0.1",
         "wicg-inert": "^3.0.0"
-      },
-      "dependencies": {
-        "@lit/reactive-element": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-          "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.0.0"
-          }
-        },
-        "lit": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-          "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-          "requires": {
-            "@lit/reactive-element": "^1.6.0",
-            "lit-element": "^3.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-element": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.1.0",
-            "@lit/reactive-element": "^1.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-html": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-          "requires": {
-            "@types/trusted-types": "^2.0.2"
-          }
-        }
-      }
-    },
-    "@material/mwc-fab": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-fab/-/mwc-fab-0.27.0.tgz",
-      "integrity": "sha512-7XUxeO14etuXe0FQdB1Y6bg8TilbQKX/NGi9b0O6D0hkcY3Y0Vk2xyoAvQArbHRz3hGfiH1cS7FaJGRSilWcjg==",
-      "requires": {
-        "@material/mwc-ripple": "^0.27.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
       },
       "dependencies": {
         "@lit/reactive-element": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@material/mwc-circular-progress": "^0.27.0",
     "@material/mwc-dialog": "^0.27.0",
     "@material/mwc-drawer": "^0.27.0",
-    "@material/mwc-fab": "^0.27.0",
     "@material/mwc-formfield": "^0.27.0",
     "@material/mwc-icon": "^0.27.0",
     "@material/mwc-icon-button": "^0.27.0",

--- a/src/views/GrampsjsViewDnaBase.js
+++ b/src/views/GrampsjsViewDnaBase.js
@@ -3,7 +3,7 @@
 import {css, html} from 'lit'
 
 import '@material/web/select/filled-select'
-import '@material/mwc-fab'
+import '@material/web/fab/fab.js'
 
 import {GrampsjsView} from './GrampsjsView.js'
 import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
@@ -23,7 +23,7 @@ export class GrampsjsViewDnaBase extends GrampsjsStaleDataMixin(GrampsjsView) {
     return [
       super.styles,
       css`
-        mwc-fab {
+        md-fab {
           position: fixed;
           bottom: 32px;
           right: 32px;

--- a/src/views/GrampsjsViewDnaMatches.js
+++ b/src/views/GrampsjsViewDnaMatches.js
@@ -1,6 +1,8 @@
 import {html} from 'lit'
+import {mdiPencil, mdiPlus} from '@mdi/js'
 
 import '@material/web/select/filled-select'
+import '../components/GrampsjsIcon.js'
 
 import '../components/GrampsjsTasks.js'
 import '../components/GrampsjsDnaMatches.js'
@@ -33,8 +35,20 @@ export class GrampsjsViewDnaMatches extends GrampsjsViewDnaBase {
 
   renderFab() {
     return this.grampsIdMatch
-      ? html`<mwc-fab icon="edit" @click=${this._handleClickEdit}></mwc-fab>`
-      : html`<mwc-fab icon="add" @click=${this._handleClickAdd}></mwc-fab>`
+      ? html`<md-fab variant="secondary" @click=${this._handleClickEdit}>
+          <grampsjs-icon
+            slot="icon"
+            .path="${mdiPencil}"
+            color="var(--mdc-theme-on-secondary)"
+          ></grampsjs-icon>
+        </md-fab>`
+      : html`<md-fab variant="secondary" @click=${this._handleClickAdd}>
+          <grampsjs-icon
+            slot="icon"
+            .path="${mdiPlus}"
+            color="var(--mdc-theme-on-secondary)"
+          ></grampsjs-icon>
+        </md-fab>`
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/views/GrampsjsViewObject.js
+++ b/src/views/GrampsjsViewObject.js
@@ -2,8 +2,9 @@
 /* eslint-disable class-methods-use-this */
 import {css, html} from 'lit'
 
-import '@material/mwc-fab'
-import '@material/mwc-icon'
+import {mdiPencil} from '@mdi/js'
+import '@material/web/fab/fab.js'
+import '../components/GrampsjsIcon.js'
 
 import {GrampsjsView} from './GrampsjsView.js'
 
@@ -55,7 +56,7 @@ export class GrampsjsViewObject extends GrampsjsView {
         :host {
         }
 
-        mwc-fab {
+        md-fab {
           position: fixed;
           bottom: 32px;
           right: 32px;
@@ -111,7 +112,13 @@ export class GrampsjsViewObject extends GrampsjsView {
 
   renderFab() {
     return html`
-      <mwc-fab icon="edit" @click="${this._activateEditMode}"></mwc-fab>
+      <md-fab variant="secondary" @click="${this._activateEditMode}">
+        <grampsjs-icon
+          slot="icon"
+          .path="${mdiPencil}"
+          color="var(--mdc-theme-on-secondary)"
+        ></grampsjs-icon>
+      </md-fab>
     `
   }
 

--- a/src/views/GrampsjsViewObjectsBase.js
+++ b/src/views/GrampsjsViewObjectsBase.js
@@ -3,11 +3,12 @@ Base view for lists of Gramps objects, e.g. people, events, ...
 */
 
 import {html, css} from 'lit'
-import {mdiSort, mdiSortAscending, mdiSortDescending} from '@mdi/js'
+import {mdiPlus, mdiSort, mdiSortAscending, mdiSortDescending} from '@mdi/js'
 
-import '@material/mwc-fab'
+import '@material/web/fab/fab.js'
 import '@material/mwc-icon-button'
 import '@material/mwc-icon'
+import '../components/GrampsjsIcon.js'
 import {classMap} from 'lit/directives/class-map.js'
 
 import {GrampsjsView} from './GrampsjsView.js'
@@ -98,7 +99,7 @@ export class GrampsjsViewObjectsBase extends GrampsjsStaleDataMixin(
           top: -4px;
         }
 
-        mwc-fab {
+        md-fab {
           position: fixed;
           bottom: 32px;
           right: 32px;
@@ -231,7 +232,15 @@ export class GrampsjsViewObjectsBase extends GrampsjsStaleDataMixin(
   }
 
   renderFab() {
-    return html` <mwc-fab icon="add" @click=${this._handleClickAdd}></mwc-fab> `
+    return html`
+      <md-fab variant="secondary" @click=${this._handleClickAdd}>
+        <grampsjs-icon
+          slot="icon"
+          .path="${mdiPlus}"
+          color="var(--mdc-theme-on-secondary)"
+        ></grampsjs-icon>
+      </md-fab>
+    `
   }
 
   _handleFiltersChanged() {

--- a/src/views/GrampsjsViewTasks.js
+++ b/src/views/GrampsjsViewTasks.js
@@ -1,7 +1,10 @@
 import {css, html} from 'lit'
+import {mdiPlus} from '@mdi/js'
 
+import '@material/web/fab/fab.js'
 import {GrampsjsView} from './GrampsjsView.js'
 import '../components/GrampsjsTasks.js'
+import '../components/GrampsjsIcon.js'
 import {GrampsjsStaleDataMixin} from '../mixins/GrampsjsStaleDataMixin.js'
 
 import {fireEvent} from '../util.js'
@@ -11,7 +14,7 @@ export class GrampsjsViewTasks extends GrampsjsStaleDataMixin(GrampsjsView) {
     return [
       super.styles,
       css`
-        mwc-fab {
+        md-fab {
           position: fixed;
           bottom: 32px;
           right: 32px;
@@ -48,7 +51,15 @@ export class GrampsjsViewTasks extends GrampsjsStaleDataMixin(GrampsjsView) {
   }
 
   renderFab() {
-    return html` <mwc-fab icon="add" @click=${this._handleClickAdd}></mwc-fab> `
+    return html`
+      <md-fab variant="secondary" @click=${this._handleClickAdd}>
+        <grampsjs-icon
+          slot="icon"
+          .path="${mdiPlus}"
+          color="var(--mdc-theme-on-secondary)"
+        ></grampsjs-icon>
+      </md-fab>
+    `
   }
 
   _handleClickAdd() {

--- a/src/views/GrampsjsViewYDna.js
+++ b/src/views/GrampsjsViewYDna.js
@@ -1,7 +1,7 @@
 import {html, css} from 'lit'
 
 import '@material/web/select/filled-select'
-import {mdiEye, mdiPencil} from '@mdi/js'
+import {mdiEye, mdiPencil, mdiPlus} from '@mdi/js'
 
 import '../components/GrampsjsYtreeLineage.js'
 import '../components/GrampsjsFormNewYDna.js'
@@ -35,7 +35,13 @@ export class GrampsjsViewYDna extends GrampsjsViewDnaBase {
   }
 
   renderFab() {
-    return html`<mwc-fab icon="add" @click="${this._handleClickAdd}"></mwc-fab>`
+    return html`<md-fab variant="secondary" @click="${this._handleClickAdd}">
+      <grampsjs-icon
+        slot="icon"
+        .path="${mdiPlus}"
+        color="var(--mdc-theme-on-secondary)"
+      ></grampsjs-icon>
+    </md-fab>`
   }
 
   get _leafCladeName() {


### PR DESCRIPTION
Replace all uses of @material/mwc-fab with @material/web/fab/fab.js. Icons use grampsjs-icon in slot="icon" with MDI paths. Colors are overridden via CSS custom properties in :root to match the previous mwc-fab appearance (blue background, white icon).