### PR TITLE
Replace mwc- by md- elements in map searchbox

### DIFF
--- a/src/components/GrampsjsMapSearchbox.js
+++ b/src/components/GrampsjsMapSearchbox.js
@@ -1,12 +1,20 @@
 import {html, css, LitElement} from 'lit'
-import '@material/mwc-icon'
-import '@material/mwc-list'
-import '@material/mwc-list/mwc-list-item'
-import '@material/mwc-icon-button'
+import '@material/web/iconbutton/icon-button.js'
+import '@material/web/list/list'
+import '@material/web/list/list-item'
 import '@material/web/textfield/outlined-text-field'
 import '@material/web/dialog/dialog'
 import '@material/web/button/text-button'
 import '@material/web/switch/switch'
+
+import {
+  mdiClose,
+  mdiMagnify,
+  mdiFilterVariant,
+  mdiMapMarker,
+  mdiMapMarkerOff,
+} from '@mdi/js'
+import './GrampsjsIcon.js'
 
 import {classMap} from 'lit/directives/class-map.js'
 import {sharedStyles} from '../SharedStyles.js'
@@ -35,22 +43,13 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
           width: 350px;
           top: 90px;
           padding: 0px;
-          --mdc-text-field-outlined-idle-border-color: var(
-            --grampsjs-body-font-color-20
-          );
-          --mdc-text-field-outlined-hover-border-color: var(
-            --grampsjs-body-font-color-38
-          );
-          --mdc-text-field-outlined-disabled-border-color: var(
-            --grampsjs-body-font-color-6
-          );
         }
 
         md-outlined-text-field {
           width: 100%;
         }
 
-        md-outlined-text-field mwc-icon-button {
+        md-outlined-text-field md-icon-button {
           color: var(--grampsjs-body-font-color-50);
         }
 
@@ -96,10 +95,6 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
 
         #searchresult-content {
           font-size: 14px;
-        }
-
-        #searchresult-content mwc-list-item {
-          --mdc-list-item-graphic-margin: 16px;
         }
 
         .hidden {
@@ -173,16 +168,14 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
             <div slot="trailing-icon">
               ${this._showClearButton
                 ? html`
-                    <mwc-icon-button
-                      icon="clear"
-                      @click="${this._handleClear}"
-                    ></mwc-icon-button>
+                    <md-icon-button @click="${this._handleClear}">
+                      <grampsjs-icon path="${mdiClose}"></grampsjs-icon>
+                    </md-icon-button>
                   `
                 : html`
-                    <mwc-icon-button
-                      icon="search"
-                      @click="${this._handleInput}"
-                    ></mwc-icon-button>
+                    <md-icon-button @click="${this._handleInput}">
+                      <grampsjs-icon path="${mdiMagnify}"></grampsjs-icon>
+                    </md-icon-button>
                   `}
               <div style="position: relative; display: inline-block;">
                 ${filterHasBadge
@@ -202,10 +195,9 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
                       </svg>
                     `
                   : ''}
-                <mwc-icon-button
-                  icon="filter_alt"
-                  @click="${this._handleFilter}"
-                ></mwc-icon-button>
+                <md-icon-button @click="${this._handleFilter}">
+                  <grampsjs-icon path="${mdiFilterVariant}"></grampsjs-icon>
+                </md-icon-button>
               </div>
             </div>
           </md-outlined-text-field>
@@ -216,30 +208,29 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
     `
   }
 
-  // eslint-disable-next-line class-methods-use-this
   _renderResults() {
     return html`
       <div id="searchresult">
         <div id="searchresult-content">
-          <mwc-list id="searchresult-list" @selected="${this._handleSelected}">
-            ${this.data.map(this._renderListItem)}
-          </mwc-list>
+          <md-list id="searchresult-list">
+            ${this.data.map((obj, i) => this._renderListItem(obj, i))}
+          </md-list>
         </div>
       </div>
     `
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  _renderListItem(obj) {
+  _renderListItem(obj, i) {
     return html`
-      <mwc-list-item graphic="icon">
+      <md-list-item type="button" @click="${() => this._handleSelected(i)}">
         ${obj.object?.profile?.name || ''}
-        <mwc-icon slot="graphic"
-          >${obj.object.lat && obj.object.long
-            ? 'place'
-            : 'location_off'}</mwc-icon
-        >
-      </mwc-list-item>
+        <grampsjs-icon
+          slot="start"
+          path="${obj.object.lat && obj.object.long
+            ? mdiMapMarker
+            : mdiMapMarkerOff}"
+        ></grampsjs-icon>
+      </md-list-item>
     `
   }
 
@@ -296,7 +287,7 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
   _handleKeyDown(event) {
     if (event.code === 'ArrowDown') {
       const lst = this.renderRoot.querySelector(
-        '#searchresult-list > mwc-list-item'
+        '#searchresult-list > md-list-item'
       )
       if (lst) {
         lst.focus()
@@ -326,11 +317,10 @@ class GrampsjsMapSearchbox extends GrampsjsAppStateMixin(LitElement) {
     }
   }
 
-  _handleSelected(event) {
+  _handleSelected(index) {
     if (this.data.length === 0) {
       return
     }
-    const {index} = event.detail
     fireEvent(this, 'mapsearch:selected', {object: this.data[index].object})
     this.detailsOpen = true
   }


### PR DESCRIPTION
[AI generated summary]

This pull request updates the `GrampsjsMapSearchbox` component to use the latest Material Web Components (`@material/web`) instead of the deprecated Material Web Components (`@material/mwc`). It also refactors icon usage to rely on Material Design Icons (MDI) and a custom `grampsjs-icon` component, improving consistency and maintainability. The event handling and rendering logic for search results have also been updated to match the new component APIs.

**Migration to Material Web Components and Icon Refactor:**

* Replaced all usages of `mwc-icon-button`, `mwc-list`, and `mwc-list-item` with their `@material/web` equivalents (`md-icon-button`, `md-list`, `md-list-item`). [[1]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL2-R18) [[2]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL219-R233)
* Updated icon rendering to use Material Design Icons (`@mdi/js`) with the custom `grampsjs-icon` component, replacing the previous `icon` attribute approach. [[1]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL2-R18) [[2]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL176-R178) [[3]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL205-R200) [[4]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL219-R233)

**Search Results Rendering and Event Handling:**

* Refactored the search results list rendering to use `md-list` and `md-list-item`, and updated the click event handling to pass the item index directly, aligning with the new component API. [[1]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL219-R233) [[2]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL329-L333)
* Updated the icon logic in search result items to use the appropriate MDI icons for location status.
* Adjusted keyboard navigation selectors and removed deprecated CSS custom properties related to the old `mwc` components. [[1]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL299-R290) [[2]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL38-R52) [[3]](diffhunk://#diff-84666783a4717f9ced98509ff49ec6f8eb2427912f3f9c9da4fceb2d96c4a0edL101-L104)