### PR TITLE
Fix select dropdown clipped by dialog overflow

### DIFF
--- a/src/components/GrampsjsFormSelectType.js
+++ b/src/components/GrampsjsFormSelectType.js
@@ -127,6 +127,7 @@ class GrampsjsFormSelectType extends GrampsjsAppStateMixin(LitElement) {
               label="${this.label}"
               .value="${this.value}"
               id="select-type"
+              menu-positioning="fixed"
             >
               <md-select-option value="">
                 <div slot="headline"></div>

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -202,6 +202,19 @@ export class GrampsjsObjectForm extends GrampsjsAppStateMixin(LitElement) {
 
   firstUpdated() {
     this.updateTypeData()
+    this._fixDialogOverflow()
+  }
+
+  _fixDialogOverflow() {
+    const dialog = this.renderRoot.querySelector('md-dialog')
+    if (dialog) {
+      dialog.updateComplete.then(() => {
+        const container = dialog.shadowRoot?.querySelector('.container')
+        const scroller = dialog.shadowRoot?.querySelector('.scroller')
+        if (container) container.style.overflow = 'visible'
+        if (scroller) scroller.style.overflow = 'visible'
+      })
+    }
   }
 
   translateTypeName(isCustom, typeKey, string) {


### PR DESCRIPTION
Override overflow on md-dialog's internal .container and .scroller elements to prevent them from clipping the md-filled-select dropdown menu. Also set menu-positioning="fixed" on the select component.

Before:
<img width="738" height="346" alt="image" src="https://github.com/user-attachments/assets/75cc1915-64e3-4e90-82f7-324addae36c1" />

After:
<img width="1474" height="974" alt="image" src="https://github.com/user-attachments/assets/a2ac6396-a2cd-4f06-a8f9-202f2b2bced5" />

