### PR TITLE
Add a visual cue for a person's self in the sibling list.

### DIFF
--- a/src/components/GrampsjsChildren.js
+++ b/src/components/GrampsjsChildren.js
@@ -1,4 +1,4 @@
-import {html} from 'lit'
+import {html, css} from 'lit'
 
 import '@material/mwc-button'
 import '@material/mwc-icon-button'
@@ -28,6 +28,17 @@ export class GrampsjsChildren extends GrampsjsEditableTable {
     }
   }
 
+  static get styles() {
+    return [
+      super.styles,
+      css`
+        tr.highlight {
+          background-color: var(--grampsjs-color-skeleton-shine);
+        }
+      `,
+    ]
+  }
+
   constructor() {
     super()
     this.profile = []
@@ -40,7 +51,9 @@ export class GrampsjsChildren extends GrampsjsEditableTable {
     return html`
       <tr
         @click=${() => this._handleClick(this.profile[i].gramps_id)}
-        class="${obj.gramps_id === this.highlightId ? 'highlight' : ''}"
+        class="${this.profile[i].gramps_id === this.highlightId
+          ? 'highlight'
+          : ''}"
       >
         <td>${genderIcon(this.profile[i]?.sex)}</td>
         <td>${this.profile[i]?.name_given || ''}</td>


### PR DESCRIPTION
Hi everyone, I am just learning how Gramps Web works on the dev side and also how to correctly contribute here...

This PR has some minimal changes that (finally) highlights the currently viewed person among its siblings in the list.

<img width="481" height="643" alt="image" src="https://github.com/user-attachments/assets/f16cefd5-1c41-4e8e-b294-b9ec3f121803" />

I hope the color I chose is considered tasteful and to reuse `grampsjs-color-skeleton-shine` is allowed. It should be always a bit lighter than the hover color.

Any hints for being a better contributor in the future is welcome of course.

Best regards!