### PR TITLE
Add SVG title element to cells in fan view to enable tooltips

### DIFF
--- a/src/charts/FanChart.js
+++ b/src/charts/FanChart.js
@@ -380,6 +380,14 @@ export function FanChart(
     .style('cursor', 'pointer')
     .on('click', clicked)
 
+  cell
+    .append('title')
+    .text(d =>
+      nameDisplayFormat === chartNameDisplayFormat.surnameThenGiven
+        ? '' + d.data.name_surname + ', ' + d.data.name_given
+        : '' + d.data.name_given + ' ' + d.data.name_surname
+    )
+
   const fontSize = d => Math.min(12, (((d.y0 + d.y1) / 2) * (d.x1 - d.x0)) / 10)
 
   const clipString = (s, d, isCenter = false) => {


### PR DESCRIPTION
Well, I hope this one does not interfere with any planned changes. I could not find issues regarding that topic but think it's a helpful addition:

<img width="927" height="646" alt="image" src="https://github.com/user-attachments/assets/8a44b61a-51b5-44ee-9125-f69c24fc9605" />