### PR TITLE
Avoid duplicate home person fetch, lazily fetch user info

### DIFF
--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -778,6 +778,9 @@ export class GrampsJs extends LitElement {
         `/api/people/?gramps_id=${grampsId}&profile=self&extend=media_list`
       )
       .then(data => {
+        if (grampsId !== this._homePersonFetchingId) {
+          return
+        }
         this._homePersonFetchingId = null
         if ('data' in data) {
           ;[this._homePersonDetails] = data.data

--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -122,6 +122,7 @@ export class GrampsJs extends LitElement {
     this.progress = false
     this.loadingState = LOADING_STATE_INITIAL
     this._homePersonDetails = {}
+    this._homePersonFetchingId = null
     this._showShortcuts = false
     this._shortcutPressed = ''
     this._firstRunToken = ''
@@ -768,14 +769,16 @@ export class GrampsJs extends LitElement {
 
   _loadHomePersonInfo() {
     const grampsId = this.appState.settings.homePerson
-    if (!grampsId) {
+    if (!grampsId || grampsId === this._homePersonFetchingId) {
       return
     }
+    this._homePersonFetchingId = grampsId
     this.appState
       .apiGet(
         `/api/people/?gramps_id=${grampsId}&profile=self&extend=media_list`
       )
       .then(data => {
+        this._homePersonFetchingId = null
         if ('data' in data) {
           ;[this._homePersonDetails] = data.data
         } else if ('error' in data) {

--- a/src/views/GrampsjsViewAdminSettings.js
+++ b/src/views/GrampsjsViewAdminSettings.js
@@ -444,8 +444,8 @@ export class GrampsjsViewAdminSettings extends GrampsjsView {
     }
   }
 
-  connectedCallback() {
-    super.connectedCallback()
+  firstUpdated() {
+    super.firstUpdated()
     this._fetchOwnUserDetails()
     this._fetchTreeInfo()
   }

--- a/src/views/GrampsjsViewSettingsUser.js
+++ b/src/views/GrampsjsViewSettingsUser.js
@@ -138,6 +138,7 @@ export class GrampsjsViewSettingsUser extends GrampsjsView {
   firstUpdated() {
     if (this.active) {
       this._fetchDataLang()
+      this._fetchOwnUserDetails()
     }
   }
 
@@ -390,11 +391,6 @@ export class GrampsjsViewSettingsUser extends GrampsjsView {
       this.error = false
       this._userInfo = data.data
     }
-  }
-
-  connectedCallback() {
-    super.connectedCallback()
-    this._fetchOwnUserDetails()
   }
 }
 

--- a/src/views/GrampsjsViewSettingsUser.js
+++ b/src/views/GrampsjsViewSettingsUser.js
@@ -137,7 +137,6 @@ export class GrampsjsViewSettingsUser extends GrampsjsView {
 
   firstUpdated() {
     if (this.active) {
-      this._fetchDataLang()
       this._fetchOwnUserDetails()
     }
   }


### PR DESCRIPTION
[AI generated summary]

This pull request introduces several improvements to the way user and home person details are fetched and managed in the application. The main changes focus on preventing redundant API calls, ensuring user details are loaded at the correct lifecycle stage, and improving data fetching logic in both the admin and user settings views.

**Enhancements to data fetching and lifecycle management:**

* Prevent redundant API calls for home person details by tracking the currently fetched `grampsId` with a new `_homePersonFetchingId` property in `GrampsJs`, and skipping the fetch if a request for the same ID is already in progress. (`src/GrampsJs.js`) [[1]](diffhunk://#diff-78a81a6b4812ffc31b085683db9782b4dae3ff05359cea8cf549ab2a8a4c5359R125) [[2]](diffhunk://#diff-78a81a6b4812ffc31b085683db9782b4dae3ff05359cea8cf549ab2a8a4c5359L771-R781)

**Improvements to view lifecycle hooks:**

* In `GrampsjsViewAdminSettings`, replace the use of the `connectedCallback` lifecycle method with `firstUpdated` to ensure data fetching methods (`_fetchOwnUserDetails` and `_fetchTreeInfo`) are called at the appropriate time in the component lifecycle. (`src/views/GrampsjsViewAdminSettings.js`)
* In `GrampsjsViewSettingsUser`, move the call to `_fetchOwnUserDetails` from `connectedCallback` to `firstUpdated`, and ensure it is only called when the view is active, preventing unnecessary data fetches. (`src/views/GrampsjsViewSettingsUser.js`) [[1]](diffhunk://#diff-138698aacd12be8383c9c2cac112b93e4ecb306bb0a7578c3ad695bcddf6eb15R141) [[2]](diffhunk://#diff-138698aacd12be8383c9c2cac112b93e4ecb306bb0a7578c3ad695bcddf6eb15L394-L398)