### PR TITLE
Fix bug that causes citation list to fail updating

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -758,7 +758,7 @@ export const reportCategoryIcon = {
 }
 
 export function arrayEqual(A, B) {
-  return A.length > 0 && B.length > 0 && A.every(e => B.includes(e))
+  return A.length === B.length && A.every(e => B.includes(e))
 }
 
 function _toNumber(value) {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -153,12 +153,24 @@ describe('getSortval', () => {
 })
 
 describe('arrayEqual', () => {
-  it('returns true when all elements of A are in B', () => {
-    expect(arrayEqual([1, 2], [1, 2, 3])).to.be.true
+  it('returns true for arrays with the same elements', () => {
+    expect(arrayEqual([1, 2, 3], [1, 2, 3])).to.be.true
+  })
+
+  it('returns true for arrays with the same elements in different order', () => {
+    expect(arrayEqual([3, 1, 2], [1, 2, 3])).to.be.true
+  })
+
+  it('returns false when A is a strict subset of B', () => {
+    expect(arrayEqual([1, 2], [1, 2, 3])).to.be.false
   })
 
   it('returns false when some elements of A are not in B', () => {
     expect(arrayEqual([1, 4], [1, 2, 3])).to.be.false
+  })
+
+  it('returns true for two empty arrays', () => {
+    expect(arrayEqual([], [])).to.be.true
   })
 
   it('returns false for empty A', () => {


### PR DESCRIPTION
Why it breaks: GrampsjsViewObjectsDetail.update() calls _updateData() only when the grampsIds array has actually changed. With the broken arrayEqual, removing a citation returns "equal" (new IDs are all present in old IDs), so _updateData() is never called, and grampsjs-view-source-citations keeps its stale _data.

Fixes #1082 