### PR TITLE
Strip out place name of hover popup on map for places

### DIFF
--- a/src/components/GrampsjsMapMarker.js
+++ b/src/components/GrampsjsMapMarker.js
@@ -56,7 +56,7 @@ class GrampsjsMapMarker extends LitElement {
     el.addEventListener('click', this.clickHandler.bind(this))
     // Add popup if needed
     if (this.popupLabel) {
-      el.title = this.popupLabel
+      el.title = this.popupLabel.replace(/<[^>]*>?/gm, '')
     }
     // Create the marker
     this._marker = new maplibregl.Marker({element: el})


### PR DESCRIPTION
Fixed place hover popup on map, the name is stripped out of the HTML tag using regex (fixes issue #1103 )