### PR TITLE
Fix report options: pre-populate defaults and correctly encode list-type options

### DIFF
--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -149,7 +149,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
           <mwc-textfield
             @input="${this._handleText}"
             id="${key}"
-            .value="${this._options[key] ?? ''}"
+            .value="${String(this._options[key] ?? '')}"
             helper="${this._(helper)}"
             helperPersistent
             type="${helper.includes('A number') ? 'number' : 'text'}"

--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -60,8 +60,8 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
   updated(changed) {
     super.updated(changed)
     if (changed.has('optionsDict') && Object.keys(this.optionsDict).length) {
-      // Pre-populate _options with string defaults so they are always sent
-      // to the backend even when the user only changes one field.
+      // Reset and re-populate whenever optionsDict changes (i.e. a different
+      // report is opened) so values from a previous report don't leak through.
       const stringDefaults = {}
       Object.keys(this.optionsDict)
         .filter(key => !_forbiddenOptions.includes(key))
@@ -74,12 +74,13 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
             const val = this.optionsDict[key]
             // Array-valued defaults (e.g. father_disp) must be sent to the
             // backend as bracket-notation strings so Gramps can parse them.
+            // All values are coerced to string — the API requires strings.
             stringDefaults[key] = Array.isArray(val)
               ? JSON.stringify(val)
-              : val ?? ''
+              : String(val ?? '')
           }
         })
-      this._options = {...stringDefaults, ...this._options}
+      this._options = stringDefaults
       fireEvent(this, 'report-options:changed', this._options)
     }
   }

--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -71,7 +71,12 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
             this.optionsHelp[key][2] !== null &&
             this.optionsHelp[key][2].constructor.name !== 'Array'
           ) {
-            stringDefaults[key] = this.optionsDict[key] ?? ''
+            const val = this.optionsDict[key]
+            // Array-valued defaults (e.g. father_disp) must be sent to the
+            // backend as bracket-notation strings so Gramps can parse them.
+            stringDefaults[key] = Array.isArray(val)
+              ? JSON.stringify(val)
+              : val ?? ''
           }
         })
       this._options = {...stringDefaults, ...this._options}
@@ -143,7 +148,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
           <mwc-textfield
             @input="${this._handleText}"
             id="${key}"
-            .value="${this._options[key] ?? this.optionsDict[key] ?? ''}"
+            .value="${this._options[key] ?? ''}"
             helper="${this._(helper)}"
             helperPersistent
             type="${helper.includes('A number') ? 'number' : 'text'}"

--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -69,7 +69,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
           if (
             this.optionsHelp[key] &&
             this.optionsHelp[key][2] !== null &&
-            this.optionsHelp[key][2].constructor.name !== 'Array'
+            !Array.isArray(this.optionsHelp[key][2])
           ) {
             const val = this.optionsDict[key]
             // Array-valued defaults (e.g. father_disp) must be sent to the
@@ -95,7 +95,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
 
   _renderOption(key) {
     const options = this.optionsHelp[key][2]
-    if (options.constructor.name === 'Array') {
+    if (Array.isArray(options)) {
       if (
         options.length === 2 &&
         options.sort()[0] === 'False' &&

--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -57,6 +57,28 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
     this._options = {}
   }
 
+  updated(changed) {
+    super.updated(changed)
+    if (changed.has('optionsDict') && Object.keys(this.optionsDict).length) {
+      // Pre-populate _options with string defaults so they are always sent
+      // to the backend even when the user only changes one field.
+      const stringDefaults = {}
+      Object.keys(this.optionsDict)
+        .filter(key => !_forbiddenOptions.includes(key))
+        .forEach(key => {
+          if (
+            this.optionsHelp[key] &&
+            this.optionsHelp[key][2] !== null &&
+            this.optionsHelp[key][2].constructor.name !== 'Array'
+          ) {
+            stringDefaults[key] = this.optionsDict[key] ?? ''
+          }
+        })
+      this._options = {...stringDefaults, ...this._options}
+      fireEvent(this, 'report-options:changed', this._options)
+    }
+  }
+
   render() {
     return html`
       ${Object.keys(this.optionsDict)
@@ -121,6 +143,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
           <mwc-textfield
             @input="${this._handleText}"
             id="${key}"
+            .value="${this._options[key] ?? this.optionsDict[key] ?? ''}"
             helper="${this._(helper)}"
             helperPersistent
             type="${helper.includes('A number') ? 'number' : 'text'}"

--- a/src/views/GrampsjsView.js
+++ b/src/views/GrampsjsView.js
@@ -65,20 +65,18 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
 
   firstUpdated() {
     this._hasFirstUpdated = true
-    if (this.appState.i18n.lang) {
-      this._onLangChanged(this.appState.i18n.lang)
-    }
   }
 
   updated(changed) {
     super.updated(changed)
+    const lang = this.appState?.i18n?.lang
     if (
+      lang &&
       changed.has('appState') &&
-      changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang &&
-      this.appState.i18n.lang &&
+      changed.get('appState')?.i18n?.lang !== lang &&
       this._hasFirstUpdated
     ) {
-      this._onLangChanged(this.appState.i18n.lang)
+      this._onLangChanged(lang)
     }
   }
 

--- a/src/views/GrampsjsView.js
+++ b/src/views/GrampsjsView.js
@@ -48,6 +48,10 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
     this.settings = {}
     this._errorMessage = ''
     this._hasFirstUpdated = false
+    // Tracks the lang value we last passed to _onLangChanged. Used to deduplicate
+    // calls when firstUpdated() and updated() fire in the same Lit cycle (e.g.
+    // when active and appState both change together in the same batched update).
+    this._lastLangChanged = ''
   }
 
   render() {
@@ -65,6 +69,11 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
 
   firstUpdated() {
     this._hasFirstUpdated = true
+    const lang = this.appState?.i18n?.lang
+    if (lang) {
+      this._lastLangChanged = lang
+      this._onLangChanged(lang)
+    }
   }
 
   updated(changed) {
@@ -72,16 +81,16 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
     const lang = this.appState?.i18n?.lang
     if (
       lang &&
+      lang !== this._lastLangChanged &&
       changed.has('appState') &&
-      changed.get('appState')?.i18n?.lang !== lang &&
-      this._hasFirstUpdated
+      changed.get('appState')?.i18n?.lang !== lang
     ) {
+      this._lastLangChanged = lang
       this._onLangChanged(lang)
     }
   }
 
   // Override in subclasses to fetch lang-dependent data.
-  // Called on first update (if lang already set) and whenever lang changes.
   // eslint-disable-next-line no-unused-vars
   _onLangChanged(_lang) {}
 }

--- a/src/views/GrampsjsView.js
+++ b/src/views/GrampsjsView.js
@@ -65,5 +65,24 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
 
   firstUpdated() {
     this._hasFirstUpdated = true
+    if (this.appState.i18n.lang) {
+      this._onLangChanged(this.appState.i18n.lang)
+    }
   }
+
+  updated(changed) {
+    if (
+      changed.has('appState') &&
+      changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang &&
+      this.appState.i18n.lang &&
+      this._hasFirstUpdated
+    ) {
+      this._onLangChanged(this.appState.i18n.lang)
+    }
+  }
+
+  // Override in subclasses to fetch lang-dependent data.
+  // Called on first update (if lang already set) and whenever lang changes.
+  // eslint-disable-next-line no-unused-vars
+  _onLangChanged(_lang) {}
 }

--- a/src/views/GrampsjsView.js
+++ b/src/views/GrampsjsView.js
@@ -71,6 +71,7 @@ export class GrampsjsView extends GrampsjsAppStateMixin(LitElement) {
   }
 
   updated(changed) {
+    super.updated(changed)
     if (
       changed.has('appState') &&
       changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang &&

--- a/src/views/GrampsjsViewBookmarks.js
+++ b/src/views/GrampsjsViewBookmarks.js
@@ -91,12 +91,8 @@ export class GrampsjsViewBookmarks extends GrampsjsView {
     }
   }
 
-  firstUpdated() {
-    this._hasFirstUpdated = true
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData(this.appState.i18n.lang)
-    }
+  _onLangChanged(lang) {
+    this._fetchData(lang)
   }
 
   update(changed) {

--- a/src/views/GrampsjsViewDnaBase.js
+++ b/src/views/GrampsjsViewDnaBase.js
@@ -201,10 +201,6 @@ export class GrampsjsViewDnaBase extends GrampsjsStaleDataMixin(GrampsjsView) {
     }
   }
 
-  firstUpdated() {
-    super.firstUpdated()
-  }
-
   _onLangChanged() {
     this._fetchSelectData()
   }

--- a/src/views/GrampsjsViewDnaBase.js
+++ b/src/views/GrampsjsViewDnaBase.js
@@ -155,6 +155,7 @@ export class GrampsjsViewDnaBase extends GrampsjsStaleDataMixin(GrampsjsView) {
   }
 
   updated(changed) {
+    super.updated(changed)
     if (changed.has('homePersonGrampsId') && this.homePersonGrampsId) {
       this._setGrampsIdIfNeeded()
     }
@@ -201,10 +202,11 @@ export class GrampsjsViewDnaBase extends GrampsjsStaleDataMixin(GrampsjsView) {
   }
 
   firstUpdated() {
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchSelectData()
-    }
+    super.firstUpdated()
+  }
+
+  _onLangChanged() {
+    this._fetchSelectData()
   }
 
   _fetchAllData() {

--- a/src/views/GrampsjsViewExport.js
+++ b/src/views/GrampsjsViewExport.js
@@ -254,8 +254,8 @@ export class GrampsjsViewExport extends GrampsjsView {
     }
   }
 
-  _onLangChanged(lang) {
-    this._fetchData(lang)
+  _onLangChanged() {
+    this._fetchData()
   }
 }
 

--- a/src/views/GrampsjsViewExport.js
+++ b/src/views/GrampsjsViewExport.js
@@ -239,33 +239,23 @@ export class GrampsjsViewExport extends GrampsjsView {
   }
 
   firstUpdated() {
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData(this.appState.i18n.lang)
-    }
+    super.firstUpdated()
     const permissions = getPermissions()
     this._viewPrivate = permissions.includes('ViewPrivate')
   }
 
   updated(changed) {
+    super.updated(changed)
     if (changed.has('_downloadUrl') && this._downloadUrl) {
       this._startDownload()
     }
     if (changed.has('_mediaDownloadUrl') && this._mediaDownloadUrl) {
       this._startMediaDownload()
     }
-    if (
-      changed.has('appState') &&
-      changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang
-    ) {
-      this._handleLanguageChanged(this.appState.i18n.lang)
-    }
   }
 
-  _handleLanguageChanged(lang) {
-    if (this._hasFirstUpdated) {
-      this._fetchData(lang)
-    }
+  _onLangChanged(lang) {
+    this._fetchData(lang)
   }
 }
 

--- a/src/views/GrampsjsViewRecent.js
+++ b/src/views/GrampsjsViewRecent.js
@@ -30,12 +30,6 @@ export class GrampsjsViewRecentObject extends GrampsjsView {
     this._handleStorage()
   }
 
-  _handleLanguageChanged(lang) {
-    if (this._hasFirstUpdated) {
-      this._fetchData(lang)
-    }
-  }
-
   _handleStorage() {
     const recentObjects = getRecentObjects()
     if (recentObjects !== undefined && recentObjects !== null) {
@@ -122,24 +116,15 @@ export class GrampsjsViewRecentObject extends GrampsjsView {
     }
   }
 
-  firstUpdated() {
-    this._hasFirstUpdated = true
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData(this.appState.i18n.lang)
-    }
+  _onLangChanged(lang) {
+    this._fetchData(lang)
   }
 
   updated(changed) {
+    super.updated(changed)
     if (changed.has('active') && this.active && this._isStale) {
       this._fetchData(this.appState.i18n.lang)
       this._isStale = false
-    }
-    if (
-      changed.has('appState') &&
-      changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang
-    ) {
-      this._handleLanguageChanged(this.appState.i18n.lang)
     }
   }
 }

--- a/src/views/GrampsjsViewReport.js
+++ b/src/views/GrampsjsViewReport.js
@@ -103,7 +103,11 @@ export class GrampsjsViewReport extends GrampsjsView {
   }
 
   _onLangChanged() {
-    this._fetchData()
+    // update() already fetches when reportId changes (initial load).
+    // Only re-fetch here when lang changes after data is already loaded.
+    if (this.data.id) {
+      this._fetchData()
+    }
   }
 
   update(changed) {

--- a/src/views/GrampsjsViewReport.js
+++ b/src/views/GrampsjsViewReport.js
@@ -102,14 +102,6 @@ export class GrampsjsViewReport extends GrampsjsView {
     this._updateQueryUrl()
   }
 
-  _onLangChanged() {
-    // update() already fetches when reportId changes (initial load).
-    // Only re-fetch here when lang changes after data is already loaded.
-    if (this.data.id) {
-      this._fetchData()
-    }
-  }
-
   update(changed) {
     super.update(changed)
     if (changed.has('reportId')) {

--- a/src/views/GrampsjsViewReport.js
+++ b/src/views/GrampsjsViewReport.js
@@ -98,11 +98,12 @@ export class GrampsjsViewReport extends GrampsjsView {
   }
 
   firstUpdated() {
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData(this.appState.i18n.lang)
-    }
+    super.firstUpdated()
     this._updateQueryUrl()
+  }
+
+  _onLangChanged(lang) {
+    this._fetchData(lang)
   }
 
   update(changed) {

--- a/src/views/GrampsjsViewReport.js
+++ b/src/views/GrampsjsViewReport.js
@@ -102,8 +102,8 @@ export class GrampsjsViewReport extends GrampsjsView {
     this._updateQueryUrl()
   }
 
-  _onLangChanged(lang) {
-    this._fetchData(lang)
+  _onLangChanged() {
+    this._fetchData()
   }
 
   update(changed) {

--- a/src/views/GrampsjsViewReport.js
+++ b/src/views/GrampsjsViewReport.js
@@ -116,9 +116,10 @@ export class GrampsjsViewReport extends GrampsjsView {
 
   _updateQueryUrl() {
     const options = Object.keys(this._options).reduce((r, e) => {
-      if (this._options[e] !== '') {
+      const val = `${this._options[e]}`
+      if (val !== '') {
         // eslint-disable-next-line no-param-reassign
-        r[e] = `${this._options[e]}`
+        r[e] = val
       }
       return r
     }, {})

--- a/src/views/GrampsjsViewReports.js
+++ b/src/views/GrampsjsViewReports.js
@@ -91,26 +91,8 @@ export class GrampsjsViewReports extends GrampsjsView {
     }
   }
 
-  firstUpdated() {
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData(this.appState.i18n.lang)
-    }
-  }
-
-  updated(changed) {
-    if (
-      changed.has('appState') &&
-      changed.get('appState')?.i18n?.lang !== this.appState.i18n.lang
-    ) {
-      this._handleLanguageChanged(this.appState.i18n.lang)
-    }
-  }
-
-  _handleLanguageChanged(lang) {
-    if (this._hasFirstUpdated) {
-      this._fetchData(lang)
-    }
+  _onLangChanged(lang) {
+    this._fetchData(lang)
   }
 }
 

--- a/src/views/GrampsjsViewReports.js
+++ b/src/views/GrampsjsViewReports.js
@@ -91,8 +91,8 @@ export class GrampsjsViewReports extends GrampsjsView {
     }
   }
 
-  _onLangChanged(lang) {
-    this._fetchData(lang)
+  _onLangChanged() {
+    this._fetchData()
   }
 }
 

--- a/src/views/GrampsjsViewTasks.js
+++ b/src/views/GrampsjsViewTasks.js
@@ -136,11 +136,8 @@ export class GrampsjsViewTasks extends GrampsjsStaleDataMixin(GrampsjsView) {
     this._fetchData()
   }
 
-  firstUpdated() {
-    if (this.appState.i18n.lang) {
-      // don't load before we have strings
-      this._fetchData()
-    }
+  _onLangChanged() {
+    this._fetchData()
   }
 
   handleUpdateStaleData() {


### PR DESCRIPTION
Fixes two issues with the report generation page:

- **Views not loading on first render** (`GrampsjsViewReports`, `ViewExport`, `ViewReport`, `ViewTasks`, `ViewDnaBase`): views that guarded data fetching on `i18n.lang` in `firstUpdated()` would never load if strings hadn't arrived yet at mount time. Fixes this by adding an `_onLangChanged()` hook to `GrampsjsView` that fires both on first update (if lang is already set) and on subsequent language changes, replacing duplicated boilerplate across views.

- **Empty boxes in ancestor/descendant chart reports** (closes #1014): two sub-issues:
  1. String-type report options were not pre-populated from `optionsDict` defaults, so only explicitly changed fields were sent to the backend — causing other options to be missing from the request rather than sent with their defaults.
  2. Array-valued options like `father_disp` and `mother_disp` (multi-line display format strings) were serialised by `.toString()` into comma-joined strings (e.g. `"$n,b. $b,-{d. $d}"`), which Gramps silently converts to an empty list. They are now serialised with `JSON.stringify` into bracket-notation strings (e.g. `'["$n","b. $b","-{d. $d}"]'`) that Gramps can correctly parse.
