### PR TITLE
Fix SW update: clicks were ignored and update:reload never reached th…

### DIFF
--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -347,9 +347,7 @@ export class GrampsJs extends LitElement {
           timeoutMs="-1"
           labelText="${this._('A new version of the app is available.')}"
         >
-          <mwc-button slot="action" @click=${this._postUpdateMessage}
-            >${this._('Refresh')}</mwc-button
-          >
+          <mwc-button slot="action">${this._('Refresh')}</mwc-button>
         </mwc-snackbar>
       </grampsjs-update-available>
     `
@@ -469,10 +467,6 @@ export class GrampsJs extends LitElement {
         </div>
       </div>
     `
-  }
-
-  _postUpdateMessage() {
-    fireEvent(this, 'update:reload')
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/components/GrampsjsUpdateAvailable.js
+++ b/src/components/GrampsjsUpdateAvailable.js
@@ -4,17 +4,9 @@ import '@material/mwc-snackbar'
 import '@material/mwc-button'
 
 export class GrampsjsUpdateAvailable extends PwaUpdateAvailable {
-  async connectedCallback() {
-    super.connectedCallback()
-    this.addEventListener('update:reload', this._postMessage.bind(this))
-  }
-
-  // The parent attaches a click listener via .bind(), so it can't be removed (new
-  // reference each time). Ignore clicks; only 'update:reload' should trigger an update.
+  // Use a fresh registration instead of the stored _newWorker reference, which
+  // can be stale if the component rendered before the waiting worker arrived.
   async _postMessage(e) {
-    if (e?.type === 'click') return
-
-    // Get fresh registration instead of relying on stored _newWorker reference
     if ('serviceWorker' in navigator) {
       const reg = await navigator.serviceWorker.getRegistration()
       if (reg?.waiting) {
@@ -22,8 +14,6 @@ export class GrampsjsUpdateAvailable extends PwaUpdateAvailable {
         return
       }
     }
-
-    // Fallback to parent implementation
     return super._postMessage(e)
   }
 }


### PR DESCRIPTION
…e element

The update:reload event was fired on the gramps-js root element and listened for on grampsjs-update-available (a child in the shadow DOM). Events bubble up, not down, so the listener was never triggered. Meanwhile, clicks were explicitly ignored, blocking the one path that actually worked.

Fix: remove the click guard so clicks bubble naturally from mwc-button through mwc-snackbar to grampsjs-update-available, triggering _postMessage. Use a fresh getRegistration() call (retaining the stale-_newWorker fix) and remove the dead connectedCallback override and _postUpdateMessage indirection.