### PR TITLE
Support Esc to close dialogs and ignore global shortcuts while dialogs are open

### DIFF
--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -1154,9 +1154,15 @@ export class GrampsJs extends LitElement {
   _handleKey(e) {
     const target = e.composedPath()[0]
     if (
-      ['input', 'textarea', 'select', 'option', 'mwc-list-item'].includes(
-        target.tagName.toLowerCase()
-      ) ||
+      [
+        'input',
+        'textarea',
+        'select',
+        'option',
+        'mwc-list-item',
+        'md-dialog',
+        'dialog',
+      ].includes(target.tagName.toLowerCase()) ||
       target.getAttribute('contenteditable')
     ) {
       return

--- a/src/components/GrampsjsObjectForm.js
+++ b/src/components/GrampsjsObjectForm.js
@@ -132,7 +132,11 @@ export class GrampsjsObjectForm extends GrampsjsAppStateMixin(LitElement) {
 
   render() {
     return html`
-      <md-dialog @cancel="${e => e.preventDefault()}" open>
+      <md-dialog
+        @keydown="${this._handleDialogKeydown}"
+        @cancel="${e => e.preventDefault()}"
+        open
+      >
         <div slot="headline">${this.dialogTitle}</div>
         <div slot="content" @formdata:changed="${this._handleFormData}">
           ${this.dialogIsOpen ? this.renderForm() : ''}
@@ -160,6 +164,12 @@ export class GrampsjsObjectForm extends GrampsjsAppStateMixin(LitElement) {
   _handleDialogSave() {
     fireEvent(this, 'object:save', {data: this.data})
     this._reset()
+  }
+
+  _handleDialogKeydown(e) {
+    if (e.key === 'Escape') {
+      this._handleDialogCancel()
+    }
   }
 
   _handleDialogCancel() {


### PR DESCRIPTION
When using Gramps Web I find keyboard shortcuts very helpful. 
It was inconvenient that dialogs had to be closed with the mouse rather than by pressing Esc. 
I also sometimes accidentally closed a dialog by pressing a shortcut key while a dialog was open (but not focused in a text input), which caused entered data to be lost.

This MR addresses both issues:
1. Dialogs now close reliably with the Escape key.
2. Global shortcuts are ignored while a dialog element is present in the event's composed path, preventing accidental navigation or dialog closure.