### PR TITLE
Ignore stale tokens during first run

### DIFF
--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -895,7 +895,11 @@ export class GrampsJs extends LitElement {
     const url = '/api/token/create_owner/'
     const payload = hasTree ? {tree: this.appState.path.pageId} : {}
     this.appState
-      .apiPost(url, payload, {dbChanged: false, saving: false})
+      .apiPost(url, payload, {
+        dbChanged: false,
+        saving: false,
+        skipAuth: true,
+      })
       .then(data => {
         if (!('error' in data) && data?.data?.access_token) {
           this.loadingState = LOADING_STATE_NO_OWNER

--- a/src/api.js
+++ b/src/api.js
@@ -928,21 +928,23 @@ export async function apiPutPostDelete(
   method,
   endpoint,
   payload,
-  {isJson = true, dbChanged = true, requireFresh = false} = {}
+  {isJson = true, dbChanged = true, requireFresh = false, skipAuth = false} = {}
 ) {
   let resJson
   let status
   try {
     let headers = {}
-    try {
-      const accessToken = await auth.getValidAccessToken()
-      headers = {
-        ...headers,
-        Accept: 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      }
-      // eslint-disable-next-line no-empty
-    } catch {}
+    if (!skipAuth) {
+      try {
+        const accessToken = await auth.getValidAccessToken()
+        headers = {
+          ...headers,
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        }
+        // eslint-disable-next-line no-empty
+      } catch {}
+    }
     if (isJson) {
       headers['Content-Type'] = 'application/json'
     }

--- a/test/unit/firstrun.test.js
+++ b/test/unit/firstrun.test.js
@@ -1,0 +1,53 @@
+import {describe, it, expect, vi} from 'vitest'
+import {GrampsJs} from '../../src/GrampsJs.js'
+
+describe('first run onboarding', () => {
+  it('requests the owner token without using stored auth tokens', async () => {
+    const element = Object.create(GrampsJs.prototype)
+    const apiPost = vi
+      .fn()
+      .mockResolvedValue({data: {access_token: 'first-run-token'}})
+
+    element.appState = {
+      path: {page: 'home', pageId: '', pageId2: ''},
+      apiPost,
+    }
+    element._firstRunToken = ''
+
+    element._fetchOnboardingToken()
+    await Promise.resolve()
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/token/create_owner/',
+      {},
+      {
+        dbChanged: false,
+        saving: false,
+        skipAuth: true,
+      }
+    )
+    expect(element._firstRunToken).to.equal('first-run-token')
+  })
+
+  it('keeps the tree id when requesting a tree-specific owner token', async () => {
+    const element = Object.create(GrampsJs.prototype)
+    const apiPost = vi
+      .fn()
+      .mockResolvedValue({data: {access_token: 'first-run-token'}})
+
+    element.appState = {
+      path: {page: 'firstrun', pageId: 'tree-id', pageId2: ''},
+      apiPost,
+    }
+    element._firstRunToken = ''
+
+    element._fetchOnboardingToken()
+    await Promise.resolve()
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/token/create_owner/',
+      {tree: 'tree-id'},
+      {dbChanged: false, saving: false, skipAuth: true}
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add an explicit `skipAuth` option for API write calls
- use it when requesting the first-run owner token
- cover default and tree-specific first-run onboarding token requests

## Root cause
On a fresh installation, stale tokens in browser local storage were still attached to the owner-token creation request. That could make the frontend fall back to the login page even though no user exists yet.

## Validation
- `npm test -- test/unit/firstrun.test.js test/unit/appstate.test.js`
- `npx eslint src/GrampsJs.js src/api.js test/unit/firstrun.test.js`
- `npx prettier "src/GrampsJs.js" "src/api.js" "test/unit/firstrun.test.js" --check`

Fixes #785