### PR TITLE
Allow pasting files into upload form

### DIFF
--- a/src/components/GrampsjsFormUpload.js
+++ b/src/components/GrampsjsFormUpload.js
@@ -249,33 +249,65 @@ class GrampsjsFormUpload extends GrampsjsAppStateMixin(LitElement) {
   }
 
   _handlePaste(event) {
-    if (!this._isVisible) {
+    if (!this._isVisible || this.disabled) {
       return
     }
-    const {items} = event.clipboardData
-    if (!items) {
+    const {items} = event.clipboardData || {}
+    if (!items?.length) {
       return
     }
-    // prevent other forms down on the same page from also handling the paste
-    event.stopImmediatePropagation()
     const pastedFiles = []
     for (const item of items) {
       if (item.kind === 'file') {
         const file = item.getAsFile()
-        if (file) {
+        if (file && this._acceptsFile(file)) {
           pastedFiles.push(file)
         }
       }
     }
-    if (pastedFiles.length > 0) {
-      if (this.multiple) {
-        this.files = [...this.files, ...pastedFiles]
-      } else {
-        this.files = [pastedFiles[0]]
-      }
-      this._processPreview()
-      this.handleChange()
+    if (!pastedFiles.length) {
+      return
     }
+
+    // prevent multiple upload components from consuming the same clipboard files
+    event.preventDefault()
+    event.stopImmediatePropagation()
+
+    if (this.multiple) {
+      this.files = [...this.files, ...pastedFiles]
+    } else {
+      this.files = [pastedFiles[0]]
+    }
+    this._processPreview()
+    this.handleChange()
+  }
+
+  _acceptsFile(file) {
+    const accept = this.accept?.trim()
+    if (!accept) {
+      return true
+    }
+    const acceptValues = accept
+      .split(',')
+      .map(v => v.trim().toLowerCase())
+      .filter(Boolean)
+    if (!acceptValues.length) {
+      return true
+    }
+
+    const fileName = file.name.toLowerCase()
+    const fileType = file.type.toLowerCase()
+
+    return acceptValues.some(value => {
+      if (value.startsWith('.')) {
+        return fileName.endsWith(value)
+      }
+      if (value.endsWith('/*')) {
+        const [category] = value.split('/')
+        return fileType.startsWith(`${category}/`)
+      }
+      return fileType === value
+    })
   }
 }
 window.customElements.define('grampsjs-form-upload', GrampsjsFormUpload)

--- a/test/unit/formUpload.test.js
+++ b/test/unit/formUpload.test.js
@@ -1,0 +1,127 @@
+import {describe, it, expect, vi} from 'vitest'
+
+import '../../src/components/GrampsjsFormUpload.js'
+
+const makeClipboardFileItem = file => ({
+  kind: 'file',
+  getAsFile: () => file,
+})
+
+const makePasteEvent = items => ({
+  clipboardData: {items},
+  preventDefault: vi.fn(),
+  stopImmediatePropagation: vi.fn(),
+})
+
+describe('GrampsjsFormUpload', () => {
+  it('accepts any file when accept is not set', () => {
+    const el = document.createElement('grampsjs-form-upload')
+    const file = new File(['x'], 'photo.png', {type: 'image/png'})
+
+    expect(el._acceptsFile(file)).toBe(true)
+  })
+
+  it('matches extension and mime accept filters', () => {
+    const el = document.createElement('grampsjs-form-upload')
+
+    el.accept = '.jpg, image/png, image/*'
+
+    expect(
+      el._acceptsFile(new File(['x'], 'portrait.JPG', {type: 'image/jpeg'}))
+    ).toBe(true)
+    expect(
+      el._acceptsFile(new File(['x'], 'icon.bin', {type: 'image/png'}))
+    ).toBe(true)
+    expect(
+      el._acceptsFile(new File(['x'], 'scan.webp', {type: 'image/webp'}))
+    ).toBe(true)
+    expect(
+      el._acceptsFile(new File(['x'], 'doc.pdf', {type: 'application/pdf'}))
+    ).toBe(false)
+  })
+
+  it('ignores paste when not visible', () => {
+    const el = document.createElement('grampsjs-form-upload')
+    const event = makePasteEvent([
+      makeClipboardFileItem(new File(['x'], 'photo.png', {type: 'image/png'})),
+    ])
+
+    el._isVisible = false
+    el._handlePaste(event)
+
+    expect(el.files).toEqual([])
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled()
+  })
+
+  it('uses first pasted file in single mode and emits change flow', () => {
+    const el = document.createElement('grampsjs-form-upload')
+    const png = new File(['x'], 'photo.png', {type: 'image/png'})
+    const jpg = new File(['x'], 'photo.jpg', {type: 'image/jpeg'})
+    const event = makePasteEvent([
+      makeClipboardFileItem(png),
+      makeClipboardFileItem(jpg),
+    ])
+
+    el._isVisible = true
+    el.multiple = false
+    el._processPreview = vi.fn()
+    el.handleChange = vi.fn()
+
+    el._handlePaste(event)
+
+    expect(el.files).toEqual([png])
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+    expect(el._processPreview).toHaveBeenCalledTimes(1)
+    expect(el.handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('appends accepted pasted files in multiple mode', () => {
+    const el = document.createElement('grampsjs-form-upload')
+    const existing = new File(['x'], 'existing.png', {type: 'image/png'})
+    const pastedOk = new File(['x'], 'new.jpg', {type: 'image/jpeg'})
+    const pastedReject = new File(['x'], 'doc.pdf', {type: 'application/pdf'})
+    const event = makePasteEvent([
+      makeClipboardFileItem(pastedReject),
+      makeClipboardFileItem(pastedOk),
+    ])
+
+    el._isVisible = true
+    el.multiple = true
+    el.accept = 'image/*'
+    el.files = [existing]
+    el._processPreview = vi.fn()
+    el.handleChange = vi.fn()
+
+    el._handlePaste(event)
+
+    expect(el.files).toEqual([existing, pastedOk])
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+    expect(el._processPreview).toHaveBeenCalledTimes(1)
+    expect(el.handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not consume paste when no accepted file is present', () => {
+    const el = document.createElement('grampsjs-form-upload')
+    const event = makePasteEvent([
+      makeClipboardFileItem(
+        new File(['x'], 'doc.pdf', {type: 'application/pdf'})
+      ),
+    ])
+
+    el._isVisible = true
+    el.accept = 'image/*'
+    el._processPreview = vi.fn()
+    el.handleChange = vi.fn()
+
+    el._handlePaste(event)
+
+    expect(el.files).toEqual([])
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled()
+    expect(el._processPreview).not.toHaveBeenCalled()
+    expect(el.handleChange).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add paste-to-upload support in the upload form component
- consume paste only when clipboard contains accepted files
- respect existing upload constraints (disabled, accept, multiple) for pasted files

## Why
- users can paste screenshots/images directly into upload flows instead of first saving files locally
- avoids breaking normal text paste behavior in other inputs/components

## Implementation details
- update paste handler in GrampsjsFormUpload to:
  - ignore paste events when component is not visible or disabled
  - extract file clipboard items and filter using accept rules
  - append or replace based on multiple
  - call preventDefault/stopImmediatePropagation only when files are consumed
  - trigger preview + formdata:changed like regular file selection
- add _acceptsFile(file) helper supporting:
  - extension tokens (e.g. .jpg)
  - explicit MIME types (e.g. image/png)
  - wildcard MIME categories (e.g. image/*)

## Testing
- checked diagnostics for modified component: no errors
- validated branch contains only src/components/GrampsjsFormUpload.js changes for this fix

## Notes
- no API changes
- no translation changes
