### PR TITLE
fix: add error handling to local storage updates in api.js

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -80,13 +80,18 @@ export function getSettings() {
 export function updateSettings(settings, tree = false) {
   const key = tree ? 'grampsjs_settings_tree' : 'grampsjs_settings'
   const settingString = localStorage.getItem(key)
-  const parsedSettings = JSON.parse(settingString) || {}
-  const treeId = getTreeId() || 'unknown'
-  const existingSettings = tree ? parsedSettings?.[treeId] : parsedSettings
-  const finalSettings = {...existingSettings, ...settings}
-  const data = tree ? {[treeId]: finalSettings} : finalSettings
-  localStorage.setItem(key, JSON.stringify(data))
-  fireEvent(window, 'settings:changed')
+  try {
+    const parsedSettings = JSON.parse(settingString) || {}
+    const treeId = getTreeId() || 'unknown'
+    const existingSettings = tree ? parsedSettings?.[treeId] : parsedSettings
+    const finalSettings = {...existingSettings, ...settings}
+    const data = tree ? {[treeId]: finalSettings} : finalSettings
+    localStorage.setItem(key, JSON.stringify(data))
+    fireEvent(window, 'settings:changed')
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to update settings:', e)
+  }
 }
 
 export function getMapViewport() {


### PR DESCRIPTION
The `updateSettings` function in `src/api.js` performs `JSON.parse` on data retrieved from `localStorage` without protection against malformed JSON, which can lead to application errors or prevent settings from being updated. This change wraps the update logic in a `try-catch` block to ensure robust handling of potential parsing errors, adhering to the project's defensive coding patterns already used in other storage management functions like `getTreeConfig` and `cleanOldDrafts`.