### PR TITLE
Add configurable custom navigation links

### DIFF
--- a/src/GrampsJs.js
+++ b/src/GrampsJs.js
@@ -423,8 +423,10 @@ export class GrampsJs extends LitElement {
                 <dd>${this._('Home')}</dd>
                 <dt><span>g</span> <span>b</span></dt>
                 <dd>${this._('Blog')}</dd>
-                <dt><span>g</span> <span>c</span></dt>
-                <dd>${this._('Family Tree')}</dd>
+                ${this.appState.frontendConfig.hideTreeLink
+                  ? ''
+                  : html`<dt><span>g</span> <span>c</span></dt>
+                      <dd>${this._('Family Tree')}</dd>`}
                 <dt><span>g</span> <span>t</span></dt>
                 <dd>${this._('Timeline')}</dd>
                 <dt><span>g</span> <span>m</span></dt>
@@ -1233,7 +1235,9 @@ export class GrampsJs extends LitElement {
       } else if (e.key === 'm') {
         fireEvent(this, 'nav', {path: 'map'})
       } else if (e.key === 'c') {
-        fireEvent(this, 'nav', {path: 'tree'})
+        if (!this.appState.frontendConfig.hideTreeLink) {
+          fireEvent(this, 'nav', {path: 'tree'})
+        }
       } else if (e.key === 'r') {
         fireEvent(this, 'nav', {path: 'recent'})
       } else if (e.key === 'f') {

--- a/src/components/GrampsjsMainMenu.js
+++ b/src/components/GrampsjsMainMenu.js
@@ -13,6 +13,7 @@ import {
   mdiDna,
   mdiHome,
   mdiImage,
+  mdiLink,
   mdiRss,
   mdiFormatListBulleted,
   mdiMap,
@@ -28,6 +29,7 @@ import {
 } from '@mdi/js'
 import {sharedStyles} from '../SharedStyles.js'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
+import {normalizeNavLinks} from '../util.js'
 import './GrampsjsIcon.js'
 
 const BASE_DIR = ''
@@ -126,6 +128,17 @@ class GrampsjsAppBar extends GrampsjsAppStateMixin(LitElement) {
     ></grampsjs-icon>`
   }
 
+  // Render a deployer-configured custom navigation link. These point outside
+  // the app's own routes, so they are never marked selected, and target is set
+  // (default '_self') to force a real navigation rather than in-app routing.
+  _renderNavLink(link) {
+    return html`
+      <md-list-item type="link" href="${link.url}" target="${link.target}">
+        ${this._icon(link.icon || mdiLink, false)} ${link.title}
+      </md-list-item>
+    `
+  }
+
   render() {
     const p = this.appState.path.page
     const listsPages = [
@@ -153,13 +166,18 @@ class GrampsjsAppBar extends GrampsjsAppStateMixin(LitElement) {
       >
         ${this._icon(mdiRss, p === 'blog')} ${this._('Blog')}
       </md-list-item>
-      <md-list-item
-        type="link"
-        href="${BASE_DIR}/tree"
-        ?selected="${p === 'tree'}"
-      >
-        ${this._icon(mdiFamilyTree, p === 'tree')} ${this._('Family Tree')}
-      </md-list-item>
+      ${this.appState.frontendConfig.hideTreeLink
+        ? ''
+        : html`
+            <md-list-item
+              type="link"
+              href="${BASE_DIR}/tree"
+              ?selected="${p === 'tree'}"
+            >
+              ${this._icon(mdiFamilyTree, p === 'tree')}
+              ${this._('Family Tree')}
+            </md-list-item>
+          `}
       <md-list-item
         type="link"
         href="${BASE_DIR}/timeline"
@@ -218,6 +236,9 @@ class GrampsjsAppBar extends GrampsjsAppStateMixin(LitElement) {
             </md-list-item>
           `
         : ''}
+      ${normalizeNavLinks(this.appState.frontendConfig.navLinks).map(link =>
+        this._renderNavLink(link)
+      )}
       <md-divider inset></md-divider>
       <md-list-item
         type="link"

--- a/src/util.js
+++ b/src/util.js
@@ -859,4 +859,38 @@ export function apiVersionAtLeast(dbInfo, major, minor, patch = 0) {
   return pat >= patch
 }
 
+// Validate and normalize deployer-configured custom navigation links
+// (window.grampsjsConfig.navLinks). Entries without a non-empty string title
+// and url are skipped with a warning rather than rendered as broken links.
+// target defaults to '_self' so that same-origin links trigger a real browser
+// navigation instead of being intercepted by the in-app (pwa-helpers) router.
+export function normalizeNavLinks(navLinks) {
+  if (!Array.isArray(navLinks)) {
+    return []
+  }
+  return navLinks.flatMap((link, i) => {
+    if (
+      typeof link?.title !== 'string' ||
+      link.title === '' ||
+      typeof link?.url !== 'string' ||
+      link.url === ''
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Ignoring invalid navLinks[${i}] in config.js: title and url must be non-empty strings`,
+        link
+      )
+      return []
+    }
+    return [
+      {
+        title: link.title,
+        url: link.url,
+        target: typeof link.target === 'string' ? link.target : '_self',
+        icon: typeof link.icon === 'string' ? link.icon : undefined,
+      },
+    ]
+  })
+}
+
 //

--- a/test/unit/navLinks.test.js
+++ b/test/unit/navLinks.test.js
@@ -1,0 +1,59 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import {normalizeNavLinks} from '../../src/util.js'
+
+describe('normalizeNavLinks', () => {
+  let warn
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it('applies defaults for a minimal valid link', () => {
+    const result = normalizeNavLinks([{title: 'Topola', url: '/topola'}])
+    expect(result).toEqual([
+      {title: 'Topola', url: '/topola', target: '_self', icon: undefined},
+    ])
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('preserves an explicit target and icon', () => {
+    const result = normalizeNavLinks([
+      {
+        title: 'Manual',
+        url: 'https://example.org/manual',
+        target: '_blank',
+        icon: 'M1',
+      },
+    ])
+    expect(result[0].target).toBe('_blank')
+    expect(result[0].icon).toBe('M1')
+  })
+
+  it('falls back to _self for a non-string target', () => {
+    const result = normalizeNavLinks([{title: 'T', url: '/u', target: 5}])
+    expect(result[0].target).toBe('_self')
+  })
+
+  it('skips invalid entries, keeps valid ones in order, and warns', () => {
+    const result = normalizeNavLinks([
+      {title: 'A', url: '/a'},
+      {title: '', url: '/b'},
+      {url: '/c'},
+      {title: 'D'},
+      {title: 1, url: '/e'},
+      {title: 'F', url: '/f'},
+    ])
+    expect(result.map(l => l.title)).toEqual(['A', 'F'])
+    expect(warn).toHaveBeenCalledTimes(4)
+  })
+
+  it('returns an empty array for non-array input', () => {
+    expect(normalizeNavLinks(undefined)).toEqual([])
+    expect(normalizeNavLinks('nope')).toEqual([])
+    expect(normalizeNavLinks([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Add configurable custom navigation links

Closes #501.

### Summary

Adds a `navLinks` frontend config option for adding custom links to the main navigation bar, and a `hideTreeLink` option to hide the built-in Family Tree link. Together they let a deployer add links to same-origin tools (e.g. an embedded tree viewer behind the same reverse proxy) or external pages such as a user manual, and optionally replace the built-in Family Tree link with one of their own.

Both options are read from `window.grampsjsConfig`, consistent with the existing `hideDNALink` / `hideRegisterLink` / `loginRedirect` options.

### Config

```javascript
window.grampsjsConfig = {
  hideTreeLink: true,
  navLinks: [
    {title: 'Family Tree', url: '/topola', icon: '<mdi svg path>'},
    {title: 'User manual', url: 'https://example.org/manual', target: '_blank'},
  ],
}
```

Per-link keys: `title` and `url` (required), `icon` (optional SVG path, defaults to a generic link icon), `target` (optional, defaults to `_self`).

### Design notes

- **`target` defaults to `_self`.** This is the load-bearing decision. Navigation uses `pwa-helpers` `installRouter`, which intercepts every same-origin anchor click that has no `target`/`download`/`rel="external"` and routes it in-app. A same-origin custom link (the common case for a reverse-proxied tool) would therefore be swallowed by the router and never reach the real page. Rendering the anchor with a `target` makes the browser perform a real navigation. `md-list-item` forwards `target` (but not `rel`), so `target` is the clean lever; `_self` keeps the link in the same tab.
- **`icon` is a raw SVG path string**, matching how `<grampsjs-icon>` already works. A name→path registry was avoided because `@mdi/js` isn't tree-shakeable by dynamic name; the alternatives are bundling the full icon set or maintaining a curated subset, both worse than letting the deployer paste a path.
- **`title` is rendered verbatim**, not passed through `_()`. Deployer-provided strings aren't in the translation catalog, and `_()` strips a leading underscore.
- **Placement:** custom links are appended at the end of the primary navigation group (before the first divider) and are never marked `selected`, since they point outside the app's own routes.
- **`hideTreeLink` mirrors `hideDNALink` exactly** — it gates the menu item, the keyboard-shortcut help entry, and the `g c` shortcut handler.
- **Invalid entries** (missing/non-string `title` or `url`) are skipped with a `console.warn` rather than rendering a broken link or throwing during render.

### Backward compatibility

Inert by default: with neither option set, behavior is unchanged.

### Testing

- New unit tests for `normalizeNavLinks` (`test/unit/navLinks.test.js`).
- Full suite green (`npm test`), `npm run lint` clean, production build (`npm run build`) succeeds.

### Docs

Companion docs PR: gramps-project/gramps-web-docs#82.

### Open question

Naming — `navLinks` vs. `customNavLinks`. Happy to rename if preferred.