### PR TITLE
Allow editing parent relationship type of an existing child reference

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -319,6 +319,7 @@
   "Any text": "Any text",
   "A list of text values. Each entry in the list represents one line of text.": "A list of text values. Each entry in the list represents one line of text.",
   "Edit repository reference": "Edit repository reference",
+  "Edit child reference": "Edit child reference",
   "Unsaved changes restored": "Unsaved changes restored",
   "Uploading file %s of %s": "Uploading file %s of %s",
   "Select files": "Select files",

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,6 +339,7 @@
   "Any text": "Any text",
   "A list of text values. Each entry in the list represents one line of text.": "A list of text values. Each entry in the list represents one line of text.",
   "Edit repository reference": "Edit repository reference",
+  "Edit child reference": "Edit child reference",
   "Unsaved changes restored": "Unsaved changes restored",
   "Uploading file %s of %s": "Uploading file %s of %s",
   "Select files": "Select files",

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,7 +339,6 @@
   "Any text": "Any text",
   "A list of text values. Each entry in the list represents one line of text.": "A list of text values. Each entry in the list represents one line of text.",
   "Edit repository reference": "Edit repository reference",
-  "Edit child reference": "Edit child reference",
   "Unsaved changes restored": "Unsaved changes restored",
   "Uploading file %s of %s": "Uploading file %s of %s",
   "Select files": "Select files",

--- a/src/components/GrampsjsChildren.js
+++ b/src/components/GrampsjsChildren.js
@@ -36,6 +36,7 @@ export class GrampsjsChildren extends GrampsjsEditableList {
     this.highlightId = ''
     this.extended = []
     this.hasShare = true
+    this.hasEdit = true
     this.hasReorder = true
     this.objType = 'ChildRef'
   }
@@ -120,6 +121,24 @@ export class GrampsjsChildren extends GrampsjsEditableList {
     `
   }
 
+  _handleEdit() {
+    const childRef = this.data[this._selectedIndex]
+    if (!childRef) {
+      return
+    }
+    this.dialogContent = html`
+      <grampsjs-form-childref
+        @object:save="${e => this._handleChildRefEdit(e, this._selectedIndex)}"
+        @object:cancel="${this._handleDialogCancel}"
+        .appState="${this.appState}"
+        .data="${childRef}"
+        objType="${this.objType}"
+        dialogTitle=${this._('Edit child reference')}
+      >
+      </grampsjs-form-childref>
+    `
+  }
+
   _handleAdd() {
     this.dialogContent = html`
       <grampsjs-form-new-child
@@ -144,6 +163,17 @@ export class GrampsjsChildren extends GrampsjsEditableList {
 
   _handleChildRefSave(e) {
     fireEvent(this, 'edit:action', {action: 'addChildRef', data: e.detail.data})
+    e.preventDefault()
+    e.stopPropagation()
+    this.dialogContent = ''
+  }
+
+  _handleChildRefEdit(e, index) {
+    fireEvent(this, 'edit:action', {
+      action: 'updateChildRef',
+      index,
+      data: e.detail.data,
+    })
     e.preventDefault()
     e.stopPropagation()
     this.dialogContent = ''

--- a/src/components/GrampsjsChildren.js
+++ b/src/components/GrampsjsChildren.js
@@ -133,7 +133,7 @@ export class GrampsjsChildren extends GrampsjsEditableList {
         .appState="${this.appState}"
         .data="${childRef}"
         objType="${this.objType}"
-        dialogTitle=${this._('Edit child reference')}
+        dialogTitle=${this._('Edit the child reference')}
       >
       </grampsjs-form-childref>
     `

--- a/src/components/GrampsjsFormChildRef.js
+++ b/src/components/GrampsjsFormChildRef.js
@@ -1,5 +1,6 @@
 /*
-Form for adding a new event reference
+Form for adding a new child reference (mode `new`) or editing the
+parent relationships (frel/mrel) of an existing one.
 */
 
 import {html} from 'lit'
@@ -16,15 +17,19 @@ import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 class GrampsjsFormChildRef extends GrampsjsObjectForm {
   renderForm() {
     return html`
-      <grampsjs-form-select-object-list
-        fixedMenuPosition
-        style="min-height: 300px;"
-        objectType="person"
-        .appState="${this.appState}"
-        id="child-select"
-        label="${this._('Select')}"
-        class="edit"
-      ></grampsjs-form-select-object-list>
+      ${this.new
+        ? html`
+            <grampsjs-form-select-object-list
+              fixedMenuPosition
+              style="min-height: 300px;"
+              objectType="person"
+              .appState="${this.appState}"
+              id="child-select"
+              label="${this._('Select')}"
+              class="edit"
+            ></grampsjs-form-select-object-list>
+          `
+        : ''}
       <grampsjs-form-select-type
         required
         id="child-frel"
@@ -33,6 +38,7 @@ class GrampsjsFormChildRef extends GrampsjsObjectForm {
         ?loadingTypes=${this.loadingTypes}
         typeName="child_reference_types"
         defaultValue="Birth"
+        .value="${this.data.frel || ''}"
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
       >
@@ -45,6 +51,7 @@ class GrampsjsFormChildRef extends GrampsjsObjectForm {
         ?loadingTypes=${this.loadingTypes}
         typeName="child_reference_types"
         defaultValue="Birth"
+        .value="${this.data.mrel || ''}"
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
       >

--- a/src/components/GrampsjsFormChildRef.js
+++ b/src/components/GrampsjsFormChildRef.js
@@ -1,5 +1,6 @@
 /*
-Form for adding a new event reference
+Form for adding a new child reference (mode `new`) or editing the
+parent relationships (frel/mrel) of an existing one.
 */
 
 import {html} from 'lit'
@@ -14,15 +15,19 @@ import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 class GrampsjsFormChildRef extends GrampsjsObjectForm {
   renderForm() {
     return html`
-      <grampsjs-form-select-object-list
-        fixedMenuPosition
-        style="min-height: 300px;"
-        objectType="person"
-        .appState="${this.appState}"
-        id="child-select"
-        label="${this._('Select')}"
-        class="edit"
-      ></grampsjs-form-select-object-list>
+      ${this.new
+        ? html`
+            <grampsjs-form-select-object-list
+              fixedMenuPosition
+              style="min-height: 300px;"
+              objectType="person"
+              .appState="${this.appState}"
+              id="child-select"
+              label="${this._('Select')}"
+              class="edit"
+            ></grampsjs-form-select-object-list>
+          `
+        : ''}
       <grampsjs-form-select-type
         required
         id="child-frel"
@@ -31,6 +36,7 @@ class GrampsjsFormChildRef extends GrampsjsObjectForm {
         ?loadingTypes=${this.loadingTypes}
         typeName="child_reference_types"
         defaultValue="Birth"
+        .value="${this.data.frel || ''}"
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
       >
@@ -43,6 +49,7 @@ class GrampsjsFormChildRef extends GrampsjsObjectForm {
         ?loadingTypes=${this.loadingTypes}
         typeName="child_reference_types"
         defaultValue="Birth"
+        .value="${this.data.mrel || ''}"
         .types="${this.types}"
         .typesLocale="${this.typesLocale}"
       >

--- a/src/components/GrampsjsFormChildRef.js
+++ b/src/components/GrampsjsFormChildRef.js
@@ -1,6 +1,6 @@
 /*
-Form for adding a new child reference (mode `new`) or editing the
-parent relationships (frel/mrel) of an existing one.
+Form for linking a child to a family, or for editing the parent
+relationships (frel/mrel) of an existing child reference.
 */
 
 import {html} from 'lit'
@@ -13,10 +13,22 @@ import './GrampsjsFormString.js'
 import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
 
 class GrampsjsFormChildRef extends GrampsjsObjectForm {
+  // the form edits an existing reference if the data it was opened with
+  // already points at a child; determined once, since selecting a person
+  // sets `ref` on the data as well
+  #isExistingRef = undefined
+
+  willUpdate() {
+    if (this.#isExistingRef === undefined) {
+      this.#isExistingRef = Boolean(this.data?.ref)
+    }
+  }
+
   renderForm() {
     return html`
-      ${this.new
-        ? html`
+      ${this.#isExistingRef
+        ? ''
+        : html`
             <grampsjs-form-select-object-list
               fixedMenuPosition
               style="min-height: 300px;"
@@ -26,8 +38,7 @@ class GrampsjsFormChildRef extends GrampsjsObjectForm {
               label="${this._('Select')}"
               class="edit"
             ></grampsjs-form-select-object-list>
-          `
-        : ''}
+          `}
       <grampsjs-form-select-type
         required
         id="child-frel"

--- a/src/strings.js
+++ b/src/strings.js
@@ -306,6 +306,7 @@ export const grampsStrings = [
   'Edit Place',
   'Edit Repository',
   'Edit Source',
+  'Edit the child reference',
   'Edit',
   'Edited',
   'Education',

--- a/src/views/GrampsjsViewObject.js
+++ b/src/views/GrampsjsViewObject.js
@@ -357,6 +357,14 @@ export class GrampsjsViewObject extends GrampsjsView {
         this._className,
         'child_ref_list'
       )
+    } else if (e.detail.action === 'updateChildRef') {
+      this.updateObjectByIndex(
+        e.detail.index,
+        e.detail.data,
+        this._data,
+        this._className,
+        'child_ref_list'
+      )
     } else if (e.detail.action === 'addNoteRef') {
       this.addHandle(
         e.detail.data.data[0],

--- a/src/views/GrampsjsViewObject.js
+++ b/src/views/GrampsjsViewObject.js
@@ -365,6 +365,14 @@ export class GrampsjsViewObject extends GrampsjsView {
         this._className,
         'child_ref_list'
       )
+    } else if (e.detail.action === 'updateChildRef') {
+      this.updateObjectByIndex(
+        e.detail.index,
+        e.detail.data,
+        this._data,
+        this._className,
+        'child_ref_list'
+      )
     } else if (e.detail.action === 'addNoteRef') {
       this.addHandle(
         e.detail.data.data[0],


### PR DESCRIPTION
Closes #1286.

## Summary

The *Children* list on a family page shows each child's relationship to the father and mother (e.g. "Father: Adopted / Mother: Birth", added in #1132), and these types can be set when **adding** a child. However, there was no way to **edit** them afterwards — the only options were to delete and re-add the child or to use the API.

This adds the standard edit (pencil) action to the children list. Selecting a child and clicking the pencil opens the child-reference form pre-filled with the current `frel`/`mrel`, mirroring how `GrampsjsPlaceRefs` edits an existing place reference.

## Changes

- **`GrampsjsChildren`**: enable `hasEdit`; `_handleEdit` opens the child-reference form pre-filled with the selected reference; on save it fires a new `updateChildRef` action (index-based), mirroring `GrampsjsPlaceRefs`.
- **`GrampsjsFormChildRef`**: make the form dual-mode — the person selector is shown only when adding (`new`); the father/mother relationship selectors are pre-populated from `data` when editing. (`child-frel`/`child-mrel` are already handled in `GrampsjsObjectForm`.)
- **`GrampsjsViewObject`**: handle the `updateChildRef` action via `updateObjectByIndex` on `child_ref_list`.
- **`lang/en.json`**: add the "Edit child reference" dialog title (other locales via Weblate).

## Testing

- `npm run lint`, `npm run typecheck`, and `npm run build` all pass.
- Deployed to a live instance and verified the edit (pencil) action opens the child-reference dialog pre-populated with the current father/mother relationship types. Saving reuses the same `updateObjectByIndex` → family `PUT` path already used for editing place references, names, etc. The add / link-existing flows are unchanged.
