### PR TITLE
Chat: render Markdown tables in assistant messages

### DIFF
--- a/src/components/GrampsjsChatMessage.js
+++ b/src/components/GrampsjsChatMessage.js
@@ -31,6 +31,12 @@ const DOMPURIFY_CONFIG = {
     'code',
     'pre',
     'a',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
   ],
   ALLOWED_ATTR: ['href'],
 }
@@ -155,6 +161,24 @@ class GrampsjsChatMessage extends GrampsjsAppStateMixin(LitElement) {
         .slot-wrap pre code {
           background: none;
           padding: 0;
+        }
+
+        .slot-wrap table {
+          display: block;
+          overflow-x: auto;
+          border-collapse: collapse;
+          margin: 0.4em 0;
+        }
+
+        .slot-wrap th,
+        .slot-wrap td {
+          border: 1px solid var(--grampsjs-color-shade-230);
+          padding: 0.2em 0.6em;
+          text-align: left;
+        }
+
+        .slot-wrap th {
+          font-weight: 600;
         }
 
         .avatar {


### PR DESCRIPTION
Fixes #1295.

Assistant replies containing GitHub-flavored Markdown tables collapsed into a single run-on line: `DOMPURIFY_CONFIG.ALLOWED_TAGS` in `GrampsjsChatMessage.js` did not include the table elements, so DOMPurify stripped them -- dropping the header row's content and concatenating the body cells' text inline (see the issue for a deterministic repro).

One file changed, two hunks:

- `ALLOWED_TAGS`: add `table`, `thead`, `tbody`, `tr`, `th`, `td`. `ALLOWED_ATTR` is unchanged (still only `href`), so the sanitizer's attribute surface is not widened. marked's `align` attribute is consequently stripped and columns render left-aligned.
- Message styles: bordered cells using the existing `--grampsjs-color-shade-230` shade, `th` at weight 600 to match the heading weight, and `display: block; overflow-x: auto` on the table so wide tables scroll horizontally instead of being clipped by `.slot-wrap`'s `overflow: hidden`.

Before / after through the component's exact pipeline (marked@18, dompurify@3.4.5; harness in the issue):

Before:

```
Here are the grandchildren, sorted by date of birth: 1 Ada Example 1901-03-16 2 Bela Example 1903-11-28
```

After:

```html
<p>Here are the grandchildren, sorted by date of birth:</p>
<table>
<thead>
<tr>
<th>#</th>
<th>Name</th>
<th>Date of birth</th>
</tr>
</thead>
<tbody><tr>
<td>1</td>
<td><a href="/person/I0001">Ada Example</a></td>
<td>1901-03-16</td>
</tr>
<tr>
<td>2</td>
<td><a href="/person/I0002">Bela Example</a></td>
<td>1903-11-28</td>
</tr>
</tbody></table>
```

## Screenshots

Assistant-generated tables now render as tables. All shots are with the patch applied.

Real data table (a person list; names, sex, and DOB redacted for this screenshot at the user's request) rendering with columns, borders, and row numbers:

<img width="1217" height="660" alt="chat-data-table-redacted" src="https://github.com/user-attachments/assets/34c60f52-64a6-415f-b174-1e37c245b46f" />

The assistant's built-in capabilities table (rendered when it declines an off-topic request), before and after the fix. Before, the cells collapse onto one line; after, it displays as a table:

Before:

<img width="1170" height="440" alt="chat-capabilities-table-collapsed-before" src="https://github.com/user-attachments/assets/e7aed8af-4419-402c-bcb2-68f5e1dfaa47" />

After:

<img width="1200" height="660" alt="chat-capabilities-table-rendered" src="https://github.com/user-attachments/assets/9da65afd-1493-4629-aba7-4097d2c813f9" />

DevTools confirming the reply is semantic `<table><thead><tbody>` HTML rather than collapsed text (the patched `.slot-wrap th, .slot-wrap td` rule is visible in the style panel):

<img width="1453" height="658" alt="chat-table-devtools-html" src="https://github.com/user-attachments/assets/836a6164-4118-4956-bb39-ce24ea534553" />

## Verification

1. Repro harness from the issue with the patched tag list: table markup survives sanitization (output above).
2. `npx vitest run`: 346 tests pass (the suite has no component tests; existing tests unaffected).
3. Manual: `npm install && npm start` against a Gramps Web API at `http://localhost:5555` (the dev-mode `__APIHOST__` in `src/api.js`) with AI chat configured. Ask the assistant for a table; it renders as a bordered table, links inside cells work, and narrowing the window shows horizontal scroll instead of clipping.