### PR TITLE
Center featured image in blog posts

### DIFF
--- a/src/components/GrampsjsBlogPost.js
+++ b/src/components/GrampsjsBlogPost.js
@@ -39,6 +39,11 @@ export class GrampsjsBlogPost extends GrampsjsAppStateMixin(LitElement) {
           text-align: center;
         }
 
+        #img-container grampsjs-img {
+          display: inline-block;
+          max-width: 100%;
+        }
+
         #image {
           margin-top: 2em;
           margin-bottom: 3em;


### PR DESCRIPTION
Fixes #1293

`#img-container` in `GrampsjsBlogPost` already sets `text-align: center`, but `grampsjs-img` renders as a block element (`:host { display: block }` in `GrampsjsImg`), so the centering never applied and the featured image sat flush left whenever it was narrower than the column.

Make the image host `inline-block` within the blog post so the existing `text-align: center` takes effect, with `max-width: 100%` so images wider than the column still shrink to fit instead of overflowing.