### PR TITLE
Fix img-container styles for alignment of images

### DIFF
--- a/src/components/GrampsjsBlogPost.js
+++ b/src/components/GrampsjsBlogPost.js
@@ -34,9 +34,9 @@ export class GrampsjsBlogPost extends GrampsjsAppStateMixin(LitElement) {
           text-align: center;
         }
 
-        #img-container {
-          width: 100%;
-          text-align: center;
+        #img-container grampsjs-img {
+          display: flex;
+          justify-content: center;
         }
 
         #image {


### PR DESCRIPTION
The blog post header photo is rendered by `GrampsjsBlogPost.js` inside a #img-container div that tries to center it with text-align: center (src/components/GrampsjsBlogPost.js:37). But text-align only centers inline content, and the actual <img> lives inside the <grampsjs-img> web component's shadow DOM, where it's styled display: block (src/components/GrampsjsImg.js:31). Block-level elements ignore text-align and hug the left edge of their container — so whenever the photo is narrower than the content column, it appears left-justified. Making the <grampsjs-img> host element a flex container centers the shadow-DOM image as a flex item. Flex layout reaches across the shadow boundary where text-align can't. 


