### PR TITLE
Feat: Blood relatives graph view under Family Tree tab

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -414,5 +414,7 @@
   "Draw a selection": "Draw a selection",
   "New Blog Post": "New Blog Post",
   "Blog Post": "Blog Post",
-  "Failed to fetch the Blog tag": "Failed to fetch the Blog tag"
+  "Failed to fetch the Blog tag": "Failed to fetch the Blog tag",
+  "Blood Relatives": "Blood Relatives",
+  "Include spouses": "Include spouses"
 }

--- a/src/treeDefaults.js
+++ b/src/treeDefaults.js
@@ -4,6 +4,7 @@ export const TREE_VIEWS = [
   'hourglass',
   'relationship',
   'fan',
+  'blood',
 ]
 
 export const DEFAULT_TREE_VIEW = 'ancestor'

--- a/src/views/GrampsjsViewBloodRelativesChart.js
+++ b/src/views/GrampsjsViewBloodRelativesChart.js
@@ -1,0 +1,82 @@
+import {GrampsjsViewRelationshipChart} from './GrampsjsViewRelationshipChart.js'
+
+// Handles of people married to someone in the given set, excluding the set
+// itself. Children of such couples are blood relatives already, so they are
+// part of the set and need no extra fetching.
+export function getSpouseHandles(people) {
+  const known = new Set(people.map(p => p.handle))
+  const spouses = new Set()
+  for (const person of people) {
+    for (const family of person.extended?.families ?? []) {
+      for (const handle of [family.father_handle, family.mother_handle]) {
+        if (handle && !known.has(handle)) {
+          spouses.add(handle)
+        }
+      }
+    }
+  }
+  return [...spouses]
+}
+
+export class GrampsjsViewBloodRelativesChart extends GrampsjsViewRelationshipChart {
+  constructor() {
+    super()
+    // the set is defined by common ancestry, not by a generation depth
+    this._setSep = false
+    this._setSpouses = true
+  }
+
+  get includeSpouses() {
+    return this.appState?.settings?.bloodRelativesSpouses ?? false
+  }
+
+  set includeSpouses(value) {
+    this.appState.updateSettings({bloodRelativesSpouses: value}, false)
+  }
+
+  _resetLevels() {
+    super._resetLevels()
+    this.includeSpouses = false
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  _getPersonRules(grampsId) {
+    return {
+      rules: [{name: 'HasCommonAncestorWith', values: [grampsId]}],
+    }
+  }
+
+  async _fetchData(grampsId) {
+    await super._fetchData(grampsId)
+    if (!this.includeSpouses || this.error || this._data.length === 0) {
+      return
+    }
+    const spouses = await this._fetchPeopleByHandle(
+      getSpouseHandles(this._data)
+    )
+    this._data = [...this._data, ...spouses]
+  }
+
+  async _fetchPeopleByHandle(handles) {
+    // chunked because gunicorn caps the request line at ~4 kB
+    const chunks = []
+    for (let i = 0; i < handles.length; i += 100) {
+      chunks.push(handles.slice(i, i + 100))
+    }
+    const results = await Promise.all(
+      chunks.map(chunk =>
+        this.appState.apiGet(
+          `/api/people/?handles=${chunk.join(',')}&locale=${
+            this.appState.i18n.lang || 'en'
+          }&profile=self&extend=event_ref_list,primary_parent_family,family_list`
+        )
+      )
+    )
+    return results.flatMap(result => result?.data ?? [])
+  }
+}
+
+window.customElements.define(
+  'grampsjs-view-blood-relatives-chart',
+  GrampsjsViewBloodRelativesChart
+)

--- a/src/views/GrampsjsViewSettingsUser.js
+++ b/src/views/GrampsjsViewSettingsUser.js
@@ -333,6 +333,8 @@ export class GrampsjsViewSettingsUser extends GrampsjsView {
         return 'Relationship Graph'
       case 'fan':
         return 'Fan Chart'
+      case 'blood':
+        return 'Blood Relatives'
       default:
         return 'Ancestor Tree'
     }

--- a/src/views/GrampsjsViewTree.js
+++ b/src/views/GrampsjsViewTree.js
@@ -3,13 +3,14 @@ import {css, html} from 'lit'
 import '@material/web/tabs/tabs'
 import '@material/web/tabs/primary-tab'
 
-import {mdiFamilyTree} from '@mdi/js'
+import {mdiAccountGroup, mdiFamilyTree} from '@mdi/js'
 import {GrampsjsView} from './GrampsjsView.js'
 import './GrampsjsViewDescendantChart.js'
 import './GrampsjsViewTreeChart.js'
 import './GrampsjsViewHourglassChart.js'
 import './GrampsjsViewFanChart.js'
 import './GrampsjsViewRelationshipChart.js'
+import './GrampsjsViewBloodRelativesChart.js'
 import {fireEvent} from '../util.js'
 import {
   chartFanIconPath,
@@ -95,6 +96,7 @@ export class GrampsjsViewTree extends GrampsjsView {
       ${this._currentTabId === 2 ? this._renderHourglassTree() : ''}
       ${this._currentTabId === 3 ? this._renderRelationshipChart() : ''}
       ${this._currentTabId === 4 ? this._renderFan() : ''}
+      ${this._currentTabId === 5 ? this._renderBloodRelatives() : ''}
     `
   }
 
@@ -145,6 +147,12 @@ export class GrampsjsViewTree extends GrampsjsView {
             >${renderIconSvg(chartFanIconPath, '--md-sys-color-primary')}</span
           >
         </md-primary-tab>
+        <md-primary-tab has-icon>
+          ${this._('Blood Relatives')}
+          <span slot="icon"
+            >${renderIconSvg(mdiAccountGroup, '--md-sys-color-primary')}</span
+          >
+        </md-primary-tab>
       </md-tabs>
     `
   }
@@ -163,6 +171,23 @@ export class GrampsjsViewTree extends GrampsjsView {
         ?disableHome=${this.grampsId === this.settings.homePerson}
       >
       </grampsjs-view-fan-chart>
+    `
+  }
+
+  _renderBloodRelatives() {
+    return html`
+      <grampsjs-view-blood-relatives-chart
+        @tree:back="${this._prevPerson}"
+        @tree:person="${this._goToPerson}"
+        @tree:home="${this._backToHomePerson}"
+        grampsId=${this.grampsId}
+        ?active=${this.active}
+        .appState="${this.appState}"
+        .settings=${this.settings}
+        ?disableBack=${this._history.length < 2}
+        ?disableHome=${this.grampsId === this.settings.homePerson}
+      >
+      </grampsjs-view-blood-relatives-chart>
     `
   }
 

--- a/src/views/GrampsjsViewTreeChartBase.js
+++ b/src/views/GrampsjsViewTreeChartBase.js
@@ -2,6 +2,7 @@ import {css, html} from 'lit'
 import {map} from 'lit/directives/map.js'
 
 import '@material/mwc-textfield'
+import '@material/web/checkbox/checkbox.js'
 import '@material/web/dialog/dialog.js'
 import '@material/web/button/text-button.js'
 import '@material/web/fab/fab.js'
@@ -109,6 +110,7 @@ export class GrampsjsViewTreeChartBase extends GrampsjsStaleDataMixin(
     this._setAnc = false
     this._setDesc = false
     this._setSep = false
+    this._setSpouses = false
     this._setMaxImages = false
     this._editMode = false
     this._boundToggleEditMode = this._toggleEditMode.bind(this)
@@ -298,6 +300,20 @@ export class GrampsjsViewTreeChartBase extends GrampsjsStaleDataMixin(
           `
         : ''
     }${
+      this._setSpouses
+        ? html`
+            <tr>
+              <td>${this._('Include spouses')}</td>
+              <td>
+                <md-checkbox
+                  ?checked=${this.includeSpouses}
+                  @change=${this._handleChangeSpouses}
+                ></md-checkbox>
+              </td>
+            </tr>
+          `
+        : ''
+    }${
       this._setMaxImages
         ? html`
             <tr>
@@ -425,6 +441,10 @@ export class GrampsjsViewTreeChartBase extends GrampsjsStaleDataMixin(
 
   _handleChangeDesc(e) {
     this.nDesc = parseInt(e.target.value, 10)
+  }
+
+  _handleChangeSpouses(e) {
+    this.includeSpouses = e.target.checked
   }
 
   _handleChangeMaxImages(e) {

--- a/test/unit/bloodRelatives.test.js
+++ b/test/unit/bloodRelatives.test.js
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest'
+import {getSpouseHandles} from '../../src/views/GrampsjsViewBloodRelativesChart.js'
+
+const person = (handle, families) => ({handle, extended: {families}})
+
+describe('getSpouseHandles', () => {
+  it('returns partners who are not blood relatives themselves', () => {
+    const people = [
+      person('me', [{father_handle: 'me', mother_handle: 'my_wife'}]),
+      person('brother', [
+        {father_handle: 'brother', mother_handle: 'sister_in_law'},
+      ]),
+    ]
+    expect(getSpouseHandles(people).sort()).to.deep.equal([
+      'my_wife',
+      'sister_in_law',
+    ])
+  })
+
+  it('excludes people already in the set and deduplicates', () => {
+    const family = {father_handle: 'dad', mother_handle: 'mom'}
+    const people = [
+      person('dad', [family]),
+      person('mom', [family]),
+      person('child', []),
+    ]
+    expect(getSpouseHandles(people)).to.deep.equal([])
+  })
+
+  it('tolerates missing families and empty partner handles', () => {
+    const people = [
+      {handle: 'me'},
+      person('sibling', [{father_handle: null, mother_handle: 'step_parent'}]),
+    ]
+    expect(getSpouseHandles(people)).to.deep.equal(['step_parent'])
+  })
+})


### PR DESCRIPTION
New Blood Relatives tab on the Family Tree page. 

The graph is based on whoever you set as home person.

The three-filter chain collapses to one rule. HasCommonAncestorWith(homePerson) matches anyone whose ancestor set intersects yours, and Gramps makes each person their own ancestor — so that's exactly ancestors(me) ∪ descendants(ancestors(me)), children included. No saved filters, no filter-editor setup, no IsDescendantOfFilterMatch (which can't be expressed inline anyway since it needs a named filter).

GrampsjsViewBloodRelativesChart.js — extends the relationship-graph view, so it inherits the graphviz renderer, controls, and edit mode; only _getPersonRules changes GrampsjsViewTree.js, treeDefaults.js, GrampsjsViewSettingsUser.js:326 — tab appended last, so existing tab indices and saved default-view settings are untouched GrampsjsViewTreeChartBase.js — _setSpouses checkbox row, following the existing _setAnc/_setDesc/_setSep pattern Spouse checkbox lives in the ⚙ Preferences dialog (where every other chart option is), persists per user, and refetches on toggle. Spouses can't be done with an inline rule (IsSpouseOfFilterMatch needs a named filter), so it collects partner handles from the blood set's families and fetches them via ?handles=, chunked at 100 to stay under gunicorn's ~4 kB request-line cap. Their kids need no special handling — a blood relative's children are blood relatives, already in the set.

Verified: lint, typecheck, unit tests for the spouse-collection logic, and a full production build to resolve the import graph. One pre-existing unrelated failure in timeline.test.js (fails on a clean checkout too — confirmed by stashing).

