### PR TITLE
Collapse unchanged fields in the revision diff viewer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -57,6 +57,8 @@
   "System": "System",
   "Light": "Light",
   "Dark": "Dark",
+  "Show unchanged fields": "Show unchanged fields",
+  "Hide unchanged fields": "Hide unchanged fields",
   "Show in tree": "Show in tree",
   "Show on timeline": "Show on timeline",
   "Open in map": "Open in map",

--- a/src/components/GrampsjsDiffJson.js
+++ b/src/components/GrampsjsDiffJson.js
@@ -1,6 +1,8 @@
 import {html, css, LitElement} from 'lit'
 import {unsafeHTML} from 'lit/directives/unsafe-html.js'
 
+import '@material/web/button/text-button'
+
 import {diff} from 'jsondiffpatch'
 import * as htmlFormatter from 'jsondiffpatch/formatters/html'
 
@@ -18,6 +20,10 @@ export class GrampsjsDiffJson extends GrampsjsAppStateMixin(LitElement) {
           --color-green: var(--grampsjs-color-revision-added-background-green);
           --color-blue: var(--grampsjs-color-revision-moved-background-blue);
           color: var(--grampsjs-body-font-color-87);
+        }
+
+        #toggle-unchanged {
+          margin-bottom: 8px;
         }
 
         #container {
@@ -201,6 +207,7 @@ export class GrampsjsDiffJson extends GrampsjsAppStateMixin(LitElement) {
       left: {type: Object},
       right: {type: Object},
       _diff: {type: Object},
+      _unchangedVisible: {type: Boolean, state: true},
     }
   }
 
@@ -209,24 +216,48 @@ export class GrampsjsDiffJson extends GrampsjsAppStateMixin(LitElement) {
     this.left = {}
     this.right = {}
     this._diff = {}
+    this._unchangedVisible = false
   }
 
   render() {
     return html`
+      <md-text-button id="toggle-unchanged" @click="${this._toggleUnchanged}">
+        ${this._unchangedVisible
+          ? this._('Hide unchanged fields')
+          : this._('Show unchanged fields')}
+      </md-text-button>
       <div id="container">
         ${unsafeHTML(htmlFormatter.format(this._diff, this.left))}
       </div>
     `
   }
 
-  updated(changed) {
+  willUpdate(changed) {
     if (changed.has('left') || changed.has('right')) {
       this._updateDiff()
+      this._unchangedVisible = false
+    }
+  }
+
+  updated(changed) {
+    if (changed.has('_diff') || changed.has('left') || changed.has('right')) {
+      const container = this.renderRoot.querySelector('#container')
+      if (container) {
+        htmlFormatter.hideUnchanged(container)
+      }
     }
   }
 
   _updateDiff() {
     this._diff = diff(this.left, this.right)
+  }
+
+  _toggleUnchanged() {
+    this._unchangedVisible = !this._unchangedVisible
+    const container = this.renderRoot.querySelector('#container')
+    if (container) {
+      htmlFormatter.showUnchanged(this._unchangedVisible, container, 300)
+    }
   }
 }
 

--- a/src/components/GrampsjsDiffJson.js
+++ b/src/components/GrampsjsDiffJson.js
@@ -221,7 +221,12 @@ export class GrampsjsDiffJson extends GrampsjsAppStateMixin(LitElement) {
 
   render() {
     return html`
-      <md-text-button id="toggle-unchanged" @click="${this._toggleUnchanged}">
+      <md-text-button
+        id="toggle-unchanged"
+        aria-pressed="${this._unchangedVisible}"
+        aria-controls="container"
+        @click="${this._toggleUnchanged}"
+      >
         ${this._unchangedVisible
           ? this._('Hide unchanged fields')
           : this._('Show unchanged fields')}


### PR DESCRIPTION
## Problem

On the revision history detail view (`/revision/<id>`), clicking a
changed object opens a jsondiffpatch-based diff of `old_data` vs.
`new_data`. For anything but a small object (e.g. a `Person` edit),
this rendered as an undifferentiated wall of raw JSON instead of a
readable diff — the actual change was there, just buried among ~100+
lines of unchanged fields with no visual distinction.

Image showing the full JSON, rather than what was designed:

<img width="1631" height="766" alt="Screenshot from 2026-08-20 12-17-09" src="https://github.com/user-attachments/assets/5c2957f4-3ce0-4c61-a0a1-d97d77857b18" />

Two separate bugs in `GrampsjsDiffJson` combined to cause this:

1. **Diff computed after the first paint.** The jsondiffpatch delta
   was computed in `updated()`, which Lit calls *after* `render()`.
   On mount, `_diff` still held its constructor default (`{}`), so the
   very first paint rendered the object with no diff markup at all
   (`format({}, left)`). Setting `_diff` inside `updated()` then
   scheduled a second, corrected re-render. In practice this meant a
   revision's diff view could show either the wrong (unhighlighted)
   frame or the right one depending on render timing — the same
   revision could look fine on one visit and look like a raw JSON dump
   on the next, even though the underlying data never changed.

2. **Unchanged fields were never collapsed.** jsondiffpatch's HTML
   formatter renders the full unchanged subtree by default and
   expects the consumer to call the separately-exported
   `hideUnchanged()` to collapse it — `GrampsjsDiffJson`'s CSS already
   had all the `.jsondiffpatch-unchanged-hidden/-showing/-hiding`
   rules for this (apparently written in anticipation of it), but the
   component never called `hideUnchanged()`. So even once the
   diff *was* computed correctly, every unchanged field still rendered
   in full, drowning out the 1-2 lines that actually changed on any
   object with more than a handful of fields.

Verified against the live diff component (both on `demo.grampsweb.org`
and a local harness) that `old_data`/`new_data` and the computed
jsondiffpatch delta were always correct — this is purely a display bug
in this component, not a data-formation issue upstream.

## Fix

In `src/components/GrampsjsDiffJson.js`:

- Move the `diff()` call from `updated()` to `willUpdate()`, which
  runs *before* `render()`, so `_diff` is correct on the very first
  paint. No more transient unhighlighted frame.
- Call `htmlFormatter.hideUnchanged()` after each render that changes
  the diff, so unchanged fields collapse by default and only the real
  changes are visible.
- Add a small "Show/Hide unchanged fields" toggle (using
  jsondiffpatch's `showUnchanged()`) so the full object is still
  reachable for context, since the CSS was already built to support
  that interaction.

## Test plan

- [x] `npx eslint src/components/GrampsjsDiffJson.js` passes
- [x] Manually verified in a local harness with a `Person`-shaped
      object (many unchanged fields, one real change): collapsed view
      shows only the changed lines by default; toggle correctly
      expands to the full object and re-collapses.
- [ ] Maintainer smoke test against a real tree's revision history

🤖 Generated with [Claude Code](https://claude.com/claude-code)