### PR TITLE
Fix empty namespace when deleting notes

### DIFF
--- a/src/views/GrampsjsViewNotes.js
+++ b/src/views/GrampsjsViewNotes.js
@@ -13,6 +13,7 @@ import '../components/GrampsjsFilterPrivate.js'
 export class GrampsjsViewNotes extends GrampsjsViewObjectsBase {
   constructor() {
     super()
+    this._objectsName = 'notes'
     this._columns = [
       {name: 'Gramps ID', key: 'grampsId', sortKey: 'gramps_id'},
       {name: 'Type', key: 'type', sortKey: 'type'},


### PR DESCRIPTION
## Summary
- `GrampsjsViewNotes` never set `_objectsName`, unlike every other `GrampsjsViewObjectsBase` subclass (People, Sources, Citations, Events, Families, MediaObjects, Places).
- As a result, deleting notes sent `{namespace: '', handles: [...]}` to `POST /api/objects/delete-by-handle/` instead of `{namespace: 'notes', ...}`.
- Sets `this._objectsName = 'notes'` in the constructor to match the existing pattern.

## Test plan
- [ ] Delete one or more notes from the Notes list view and confirm the request payload now includes `namespace: "notes"` and the notes are actually deleted.