### PR TITLE
Fix address date display

### DIFF
--- a/src/components/GrampsjsAddresses.js
+++ b/src/components/GrampsjsAddresses.js
@@ -2,6 +2,7 @@ import {html, LitElement, css} from 'lit'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 import {sharedStyles} from '../SharedStyles.js'
 import {toDate} from '../date.js'
+import {dateIsEmpty} from '../util.js'
 
 export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
   static get styles() {
@@ -116,13 +117,19 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
 
   // Date to show for the address at the given index. Prefers the string
   // formatted by the API, which honours modifiers, calendars and locale.
-  // Falls back to the raw date only when the object was loaded without a
-  // profile.
+  //
+  // The fallback formats the raw date, for backends predating
+  // https://github.com/gramps-project/gramps-web-api/pull/949, which added
+  // addresses to the profile of every object type that has them. It can be
+  // removed once the minimum supported backend includes that change.
   _dateString(obj, i) {
-    return (
-      this.profile[i]?.date_str ??
-      (obj?.date?.dateval ? toDate(obj.date.dateval) : '')
-    )
+    const dateStr = this.profile[i]?.date_str
+    if (dateStr !== undefined) {
+      return dateStr
+    }
+    return obj?.date?.dateval && !dateIsEmpty(obj.date)
+      ? toDate(obj.date.dateval)
+      : ''
   }
 }
 

--- a/src/components/GrampsjsAddresses.js
+++ b/src/components/GrampsjsAddresses.js
@@ -1,6 +1,7 @@
 import {html, LitElement, css} from 'lit'
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 import {sharedStyles} from '../SharedStyles.js'
+import {toDate} from '../date.js'
 
 export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
   static get styles() {
@@ -32,12 +33,14 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
   static get properties() {
     return {
       data: {type: Object},
+      profile: {type: Array},
     }
   }
 
   constructor() {
     super()
     this.data = {}
+    this.profile = []
   }
 
   render() {
@@ -46,13 +49,13 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
     }
     return html`
     ${this.data.map(
-      obj => html`
+      (obj, i) => html`
         <dl>
-          ${obj?.date?.dateval
+          ${this._dateString(obj, i)
             ? html`
                 <div>
                   <dt>${this._('Date')}</dt>
-                  <dd>${this._toDate(obj?.date?.dateval)}</dd>
+                  <dd>${this._dateString(obj, i)}</dd>
                 </div>
               `
             : ''}
@@ -111,13 +114,14 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
     `
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  _toDate(dateVal) {
-    try {
-      return `${dateVal[2]}-${dateVal[1]}-${dateVal[0]}`
-    } catch {
-      return ''
-    }
+  // Date to show for the address at the given index. Prefers the string
+  // formatted by the API. Object types without the address in profile
+  // fall back to formatting the raw date.
+  _dateString(obj, i) {
+    return (
+      this.profile[i]?.date_str ??
+      (obj?.date?.dateval ? toDate(obj.date.dateval) : '')
+    )
   }
 }
 

--- a/src/components/GrampsjsAddresses.js
+++ b/src/components/GrampsjsAddresses.js
@@ -115,8 +115,9 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
   }
 
   // Date to show for the address at the given index. Prefers the string
-  // formatted by the API. Object types without the address in profile
-  // fall back to formatting the raw date.
+  // formatted by the API, which honours modifiers, calendars and locale.
+  // Falls back to the raw date only when the object was loaded without a
+  // profile.
   _dateString(obj, i) {
     return (
       this.profile[i]?.date_str ??

--- a/src/components/GrampsjsAddresses.js
+++ b/src/components/GrampsjsAddresses.js
@@ -32,19 +32,19 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
 
   static get properties() {
     return {
-      data: {type: Object},
+      data: {type: Array},
       profile: {type: Array},
     }
   }
 
   constructor() {
     super()
-    this.data = {}
+    this.data = []
     this.profile = []
   }
 
   render() {
-    if (Object.keys(this.data).length === 0) {
+    if (this.data.length === 0) {
       return ''
     }
     return html`

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -826,6 +826,7 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
                 <grampsjs-addresses
                   .appState="${this.appState}"
                   .data=${this.data.address_list ?? []}
+                  .profile=${this.data?.profile?.addresses ?? []}
                 ></grampsjs-addresses>`
             : ''}
           ${this.data.urls?.length > 0 || (this.edit && 'urls' in this.data)

--- a/test/unit/addresses.test.js
+++ b/test/unit/addresses.test.js
@@ -79,5 +79,13 @@ describe('address dates', () => {
       const rows = renderRows([{street: 'High Street'}], [])
       expect(rows).to.deep.equal([['Street', 'High Street']])
     })
+
+    it('omits the date row for an address holding an empty date', () => {
+      const rows = renderRows(
+        [{street: 'High Street', date: date([0, 0, 0, false])}],
+        []
+      )
+      expect(rows).to.deep.equal([['Street', 'High Street']])
+    })
   })
 })

--- a/test/unit/addresses.test.js
+++ b/test/unit/addresses.test.js
@@ -1,0 +1,83 @@
+import {describe, it, expect} from 'vitest'
+import {render} from 'lit'
+import {GrampsjsAddresses} from '../../src/components/GrampsjsAddresses.js'
+
+// Render the component and return its rows as [label, value] pairs.
+const renderRows = (data, profile) => {
+  const element = new GrampsjsAddresses()
+  element.appState = {i18n: {strings: {}}}
+  element.data = data
+  element.profile = profile
+
+  const shadowRoot = element.createRenderRoot()
+  render(element.render(), shadowRoot)
+
+  return [...shadowRoot.querySelectorAll('dl > div')].map(row => [
+    row.querySelector('dt').textContent,
+    row.querySelector('dd').textContent,
+  ])
+}
+
+const date = dateval => ({
+  _class: 'Date',
+  calendar: 0,
+  modifier: 0,
+  quality: 0,
+  dateval,
+  sortval: 0,
+  text: '',
+})
+
+describe('address dates', () => {
+  it('shows the date string supplied by the profile', () => {
+    const rows = renderRows(
+      [{street: 'High Street'}],
+      [{date_str: '1990-03-15'}]
+    )
+    expect(rows).to.deep.equal([
+      ['Date', '1990-03-15'],
+      ['Street', 'High Street'],
+    ])
+  })
+
+  it('omits the date row for an address the profile reports as undated', () => {
+    const rows = renderRows(
+      [{street: 'High Street', date: date([2, 1, 2000, false])}],
+      [{date_str: ''}]
+    )
+    expect(rows).to.deep.equal([['Street', 'High Street']])
+  })
+
+  it('takes the date of each address from the profile entry of the same index', () => {
+    const rows = renderRows(
+      [{street: 'High Street'}, {street: 'Mill Lane'}],
+      [{date_str: '1850'}, {date_str: '1860'}]
+    )
+    expect(rows).to.deep.equal([
+      ['Date', '1850'],
+      ['Street', 'High Street'],
+      ['Date', '1860'],
+      ['Street', 'Mill Lane'],
+    ])
+  })
+
+  // Repositories have addresses but no profile at all, so nothing formats
+  // their dates for us.
+  describe('for an object whose profile carries no addresses', () => {
+    it('falls back to formatting the date held on the address', () => {
+      const rows = renderRows(
+        [{street: 'High Street', date: date([2, 1, 2000, false])}],
+        []
+      )
+      expect(rows).to.deep.equal([
+        ['Date', '2000-1-2'],
+        ['Street', 'High Street'],
+      ])
+    })
+
+    it('omits the date row for an address with no date at all', () => {
+      const rows = renderRows([{street: 'High Street'}], [])
+      expect(rows).to.deep.equal([['Street', 'High Street']])
+    })
+  })
+})

--- a/test/unit/addresses.test.js
+++ b/test/unit/addresses.test.js
@@ -61,9 +61,9 @@ describe('address dates', () => {
     ])
   })
 
-  // Repositories have addresses but no profile at all, so nothing formats
-  // their dates for us.
-  describe('for an object whose profile carries no addresses', () => {
+  // Every object type with addresses formats their dates in its profile, so
+  // this only happens when the object was loaded without a profile.
+  describe('for an object loaded without a profile', () => {
     it('falls back to formatting the date held on the address', () => {
       const rows = renderRows(
         [{street: 'High Street', date: date([2, 1, 2000, false])}],


### PR DESCRIPTION
 Fixes #1353

An address with no date rendered as `0-0-0`, because the date row was shown whenever `date.dateval` was present and `dateval` is a truthy array (`[0, 0, 0, false]`) even when the date is empty.

Rather than fix the client-side formatting, this switches to the formatted string added to the API by gramps-project/gramps-web-api#949. If that's not available, it falls back to the original presentation but using the `src/date.js` helper.

Aside: I noted that `src/date.js` didn't appear to be used anywhere when I used it, and reflects what I think is the flawed approach of formatting the date client-side—it will result in outputting `0-0-0`, ignores the text-only modifier etc. Maybe it should be 💥 or perhaps we should reproduce the formatting logic from the backend there?