### PR TITLE
Preselect the current type when editing an internet address

### DIFF
--- a/src/components/GrampsjsFormEditUrl.js
+++ b/src/components/GrampsjsFormEditUrl.js
@@ -22,7 +22,6 @@ class GrampsjsFormEditUrl extends GrampsjsObjectForm {
           ?loadingTypes=${this.loadingTypes}
           .types="${this.types}"
           .typesLocale="${this.typesLocale}"
-          .data="${this.data}"
           value=${this.data?.type ?? ''}
         >
         </grampsjs-form-select-type>

--- a/src/components/GrampsjsFormEditUrl.js
+++ b/src/components/GrampsjsFormEditUrl.js
@@ -23,7 +23,7 @@ class GrampsjsFormEditUrl extends GrampsjsObjectForm {
           .types="${this.types}"
           .typesLocale="${this.typesLocale}"
           .data="${this.data}"
-          value=${this.data?.type?.string || ''}
+          value=${this.data?.type ?? ''}
         >
         </grampsjs-form-select-type>
       </p>


### PR DESCRIPTION
Fixes #1355

The URL edit form read the type as `type.string`, but the URL type arrives from the API as a plain string, so the dropdown always fell back to the empty option.

We are binding `.data` here but it doesn't look like the select component uses it; is this intentional or would another issue to tidy that up be useful?