### PR TITLE
Fix phone number and ftp links in Internet list

### DIFF
--- a/src/components/GrampsjsUrls.js
+++ b/src/components/GrampsjsUrls.js
@@ -15,17 +15,49 @@ function isValidEmail(email) {
   return re.test(email)
 }
 
-function fixUrl(input) {
-  let url = input
-  try {
-    url = new URL(input)
-  } catch (error) {
-    if (isValidEmail(input)) {
-      return `mailto:${input}`
-    }
-    return `https://${input}`
+function isPhoneNumber(input) {
+  // Digits and usual separators
+  if (!/^\+?[\d\s()./-]+$/.test(input)) {
+    return false
   }
-  return url
+  // Exclude IPv4 addresses
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(input)) {
+    return false
+  }
+  // Check long enough
+  return (input.match(/\d/g) || []).length >= 5
+}
+
+function parsePhoneNumber(input) {
+  // Split off a trailing extension, e.g. "ext 12", "ext. 12" or "x12"
+  const extension = input.match(/\s*(?:ext\.?|x)\s*(\d+)$/i)
+  const number = extension ? input.slice(0, extension.index) : input
+  if (!isPhoneNumber(number)) {
+    return null
+  }
+  return {number, extension: extension?.[1] ?? ''}
+}
+
+function fixUrl(url) {
+  const input = url.path
+  try {
+    return new URL(input)
+  } catch (error) {}
+
+  if (url.type === 'FTP') {
+    return `ftp://${input}`
+  }
+  if (isValidEmail(input)) {
+    return `mailto:${input}`
+  }
+  const phone = parsePhoneNumber(input)
+  if (phone) {
+    const number = phone.number.replace(/[^\d+]/g, '')
+    return phone.extension
+      ? `tel:${number};ext=${phone.extension}`
+      : `tel:${number}`
+  }
+  return `https://${input}`
 }
 
 export class GrampsjsUrls extends GrampsjsEditableList {
@@ -41,7 +73,7 @@ export class GrampsjsUrls extends GrampsjsEditableList {
         }}"
       >
         <a
-          href="${fixUrl(obj.path)}"
+          href="${fixUrl(obj)}"
           target="_blank"
           rel="noopener noreferrer"
           class="${classMap({nopointer: this.edit})}"

--- a/src/components/GrampsjsUrls.js
+++ b/src/components/GrampsjsUrls.js
@@ -7,58 +7,9 @@ import './GrampsjsFormEditUrl.js'
 import './GrampsjsIcon.js'
 
 import {fireEvent} from '../util.js'
+import {fixUrl} from '../urlUtil.js'
 
 import '@material/web/list/list-item.js'
-
-function isValidEmail(email) {
-  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-  return re.test(email)
-}
-
-function isPhoneNumber(input) {
-  // Digits and usual separators
-  if (!/^\+?[\d\s()./-]+$/.test(input)) {
-    return false
-  }
-  // Exclude IPv4 addresses
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(input)) {
-    return false
-  }
-  // Check long enough
-  return (input.match(/\d/g) || []).length >= 5
-}
-
-function parsePhoneNumber(input) {
-  // Split off a trailing extension, e.g. "ext 12", "ext. 12" or "x12"
-  const extension = input.match(/\s*(?:ext\.?|x)\s*(\d+)$/i)
-  const number = extension ? input.slice(0, extension.index) : input
-  if (!isPhoneNumber(number)) {
-    return null
-  }
-  return {number, extension: extension?.[1] ?? ''}
-}
-
-function fixUrl(url) {
-  const input = url.path
-  try {
-    return new URL(input)
-  } catch (error) {}
-
-  if (url.type === 'FTP') {
-    return `ftp://${input}`
-  }
-  if (isValidEmail(input)) {
-    return `mailto:${input}`
-  }
-  const phone = parsePhoneNumber(input)
-  if (phone) {
-    const number = phone.number.replace(/[^\d+]/g, '')
-    return phone.extension
-      ? `tel:${number};ext=${phone.extension}`
-      : `tel:${number}`
-  }
-  return `https://${input}`
-}
 
 export class GrampsjsUrls extends GrampsjsEditableList {
   row(obj, i) {
@@ -73,7 +24,7 @@ export class GrampsjsUrls extends GrampsjsEditableList {
         }}"
       >
         <a
-          href="${fixUrl(obj)}"
+          href="${fixUrl(obj.path, obj.type)}"
           target="_blank"
           rel="noopener noreferrer"
           class="${classMap({nopointer: this.edit})}"

--- a/src/urlUtil.js
+++ b/src/urlUtil.js
@@ -4,6 +4,19 @@ Gramps URL records, which may hold anything from a full URL to a bare host
 name, an email address, or a phone number.
 */
 
+// Schemes that are safe to use in a link's href.
+const SAFE_PROTOCOLS = [
+  'http:',
+  'https:',
+  'ftp:',
+  'ftps:',
+  'sftp:',
+  'mailto:',
+  'tel:',
+]
+
+const UNSAFE_HREF = '#'
+
 function isValidEmail(email) {
   const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
   return re.test(email)
@@ -37,11 +50,16 @@ function parsePhoneNumber(input) {
  *
  * @param {string} path the path as entered by the user
  * @param {string} [type] the Gramps URL type, if available, e.g. `FTP`
- * @returns {string} the href
+ * @returns {string} the href, which is always safe to use in a link
  */
 export function fixUrl(path, type) {
+  if (typeof path !== 'string' || !path) {
+    return UNSAFE_HREF
+  }
+
   try {
-    return String(new URL(path))
+    const url = new URL(path)
+    return SAFE_PROTOCOLS.includes(url.protocol) ? String(url) : UNSAFE_HREF
   } catch (error) {}
 
   if (type === 'FTP') {

--- a/src/urlUtil.js
+++ b/src/urlUtil.js
@@ -1,0 +1,61 @@
+/*
+Helpers for deriving usable hyperlinks from the free-text paths stored on
+Gramps URL records, which may hold anything from a full URL to a bare host
+name, an email address, or a phone number.
+*/
+
+function isValidEmail(email) {
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return re.test(email)
+}
+
+function isPhoneNumber(input) {
+  // Digits and usual separators
+  if (!/^\+?[\d\s()./-]+$/.test(input)) {
+    return false
+  }
+  // Exclude IPv4 addresses
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(input)) {
+    return false
+  }
+  // Check long enough
+  return (input.match(/\d/g) || []).length >= 5
+}
+
+function parsePhoneNumber(input) {
+  // Split off a trailing extension, e.g. "ext 12", "ext. 12" or "x12"
+  const extension = input.match(/\s*(?:ext\.?|x)\s*(\d+)$/i)
+  const number = extension ? input.slice(0, extension.index) : input
+  if (!isPhoneNumber(number)) {
+    return null
+  }
+  return {number, extension: extension?.[1] ?? ''}
+}
+
+/**
+ * Return an absolute URL suitable for a link's href for the given path.
+ *
+ * @param {string} path the path as entered by the user
+ * @param {string} [type] the Gramps URL type, if available, e.g. `FTP`
+ * @returns {string} the href
+ */
+export function fixUrl(path, type) {
+  try {
+    return String(new URL(path))
+  } catch (error) {}
+
+  if (type === 'FTP') {
+    return `ftp://${path}`
+  }
+  if (isValidEmail(path)) {
+    return `mailto:${path}`
+  }
+  const phone = parsePhoneNumber(path)
+  if (phone) {
+    const number = phone.number.replace(/[^\d+]/g, '')
+    return phone.extension
+      ? `tel:${number};ext=${phone.extension}`
+      : `tel:${number}`
+  }
+  return `https://${path}`
+}

--- a/src/urlUtil.js
+++ b/src/urlUtil.js
@@ -60,7 +60,9 @@ export function fixUrl(path, type) {
   try {
     const url = new URL(path)
     return SAFE_PROTOCOLS.includes(url.protocol) ? String(url) : UNSAFE_HREF
-  } catch (error) {}
+  } catch {
+    // Not an absolute URL; fall through to heuristics below.
+  }
 
   if (type === 'FTP') {
     return `ftp://${path}`

--- a/test/unit/urlUtil.test.js
+++ b/test/unit/urlUtil.test.js
@@ -1,0 +1,133 @@
+import {describe, it, expect} from 'vitest'
+
+import {fixUrl} from '../../src/urlUtil.js'
+
+describe('fixUrl', () => {
+  describe('paths that are already URLs', () => {
+    it('keeps an absolute http(s) URL unchanged', () => {
+      expect(fixUrl('https://example.com/foo?a=1')).to.equal(
+        'https://example.com/foo?a=1'
+      )
+    })
+
+    it('keeps a mailto URL unchanged', () => {
+      expect(fixUrl('mailto:john@example.com')).to.equal(
+        'mailto:john@example.com'
+      )
+    })
+
+    it('keeps a tel URL unchanged', () => {
+      expect(fixUrl('tel:+15551234567')).to.equal('tel:+15551234567')
+    })
+
+    it('keeps an ftp URL unchanged, whatever the type', () => {
+      expect(fixUrl('ftp://ftp.example.com/pub', 'FTP')).to.equal(
+        'ftp://ftp.example.com/pub'
+      )
+    })
+
+    it('normalises the URL', () => {
+      expect(fixUrl('https://example.com')).to.equal('https://example.com/')
+    })
+  })
+
+  describe('bare host names', () => {
+    it('prefixes a bare host name with https', () => {
+      expect(fixUrl('example.com')).to.equal('https://example.com')
+    })
+
+    it('prefixes a host name with a path with https', () => {
+      expect(fixUrl('www.example.com/path')).to.equal(
+        'https://www.example.com/path'
+      )
+    })
+  })
+
+  describe('FTP type', () => {
+    it('prefixes a bare host name with ftp', () => {
+      expect(fixUrl('ftp.example.com', 'FTP')).to.equal('ftp://ftp.example.com')
+    })
+
+    it('takes precedence over the email and phone number heuristics', () => {
+      expect(fixUrl('john@example.com', 'FTP')).to.equal(
+        'ftp://john@example.com'
+      )
+      expect(fixUrl('555 1234', 'FTP')).to.equal('ftp://555 1234')
+    })
+  })
+
+  describe('email addresses', () => {
+    it('turns an email address into a mailto link', () => {
+      expect(fixUrl('john@example.com')).to.equal('mailto:john@example.com')
+    })
+
+    it('does not treat an address without a dotted domain as email', () => {
+      expect(fixUrl('john@localhost')).to.equal('https://john@localhost')
+    })
+  })
+
+  describe('phone numbers', () => {
+    it('turns a bare number into a tel link', () => {
+      expect(fixUrl('5551234567')).to.equal('tel:5551234567')
+    })
+
+    it('strips spaces, brackets and dashes but keeps a leading plus', () => {
+      expect(fixUrl('+1 (555) 123-4567')).to.equal('tel:+15551234567')
+    })
+
+    it('accepts dots as separators', () => {
+      expect(fixUrl('555.123.4567')).to.equal('tel:5551234567')
+    })
+
+    it('is applied regardless of the URL type', () => {
+      expect(fixUrl('+1 555 123 4567', 'Web Home')).to.equal('tel:+15551234567')
+    })
+
+    it('requires at least five digits', () => {
+      expect(fixUrl('1234')).to.equal('https://1234')
+      expect(fixUrl('12345')).to.equal('tel:12345')
+    })
+
+    it('does not treat an IPv4 address as a phone number', () => {
+      expect(fixUrl('192.168.1.1')).to.equal('https://192.168.1.1')
+    })
+
+    it('does not treat text as a phone number', () => {
+      expect(fixUrl('Some Description')).to.equal('https://Some Description')
+    })
+
+    it('does not treat separators without digits as a phone number', () => {
+      expect(fixUrl('- - -')).to.equal('https://- - -')
+    })
+  })
+
+  describe('phone number extensions', () => {
+    it('splits off an "ext" extension', () => {
+      expect(fixUrl('0800 123 456 ext 12')).to.equal('tel:0800123456;ext=12')
+    })
+
+    it('splits off an "ext." extension', () => {
+      expect(fixUrl('(03) 555-1234 ext. 89')).to.equal('tel:035551234;ext=89')
+    })
+
+    it('splits off an "x" extension', () => {
+      expect(fixUrl('0800 123 456 x12')).to.equal('tel:0800123456;ext=12')
+    })
+
+    it('matches the extension marker case insensitively', () => {
+      expect(fixUrl('+64 21 123 4567 EXT 7')).to.equal('tel:+64211234567;ext=7')
+    })
+
+    it('ignores an extension when the rest is not a phone number', () => {
+      expect(fixUrl('Ask for Bob ext 12')).to.equal(
+        'https://Ask for Bob ext 12'
+      )
+    })
+  })
+
+  describe('missing type', () => {
+    it('treats an undefined type as not FTP', () => {
+      expect(fixUrl('ftp.example.com')).to.equal('https://ftp.example.com')
+    })
+  })
+})

--- a/test/unit/urlUtil.test.js
+++ b/test/unit/urlUtil.test.js
@@ -125,6 +125,59 @@ describe('fixUrl', () => {
     })
   })
 
+  describe('missing path', () => {
+    it('does not link an empty path', () => {
+      expect(fixUrl('')).to.equal('#')
+    })
+
+    it('does not link a path that is not a string', () => {
+      expect(fixUrl(undefined)).to.equal('#')
+      expect(fixUrl(null)).to.equal('#')
+      expect(fixUrl(42)).to.equal('#')
+    })
+  })
+
+  describe('unsafe schemes', () => {
+    it('does not link to a javascript URL', () => {
+      expect(fixUrl('javascript:alert(document.cookie)')).to.equal('#')
+    })
+
+    it('catches a javascript URL whatever its case', () => {
+      expect(fixUrl('JaVaScRiPt:alert(1)')).to.equal('#')
+    })
+
+    it('catches a javascript URL containing whitespace', () => {
+      expect(fixUrl('java\nscript:alert(1)')).to.equal('#')
+      expect(fixUrl('  javascript:alert(1)')).to.equal('#')
+    })
+
+    it('does not link to a data URL', () => {
+      expect(fixUrl('data:text/html,<script>alert(1)</script>')).to.equal('#')
+    })
+
+    it('does not link to a vbscript URL', () => {
+      expect(fixUrl('vbscript:msgbox(1)')).to.equal('#')
+    })
+
+    it('does not link to a blob or file URL', () => {
+      expect(fixUrl('blob:https://example.com/uuid')).to.equal('#')
+      expect(fixUrl('file:///etc/passwd')).to.equal('#')
+    })
+
+    it('rejects an unsafe scheme whatever the type', () => {
+      expect(fixUrl('javascript:alert(1)', 'FTP')).to.equal('#')
+    })
+
+    it('allows the schemes the app itself produces', () => {
+      expect(fixUrl('ftps://example.com/pub')).to.equal(
+        'ftps://example.com/pub'
+      )
+      expect(fixUrl('sftp://example.com/pub')).to.equal(
+        'sftp://example.com/pub'
+      )
+    })
+  })
+
   describe('missing type', () => {
     it('treats an undefined type as not FTP', () => {
       expect(fixUrl('ftp.example.com')).to.equal('https://ftp.example.com')


### PR DESCRIPTION
Fixes #1354. Continues the heuristic approach of `isValidEmail`, adding a test for phone numbers (hopefully broad enough but not too broad), and support for the FTP type. The approach for email, phone and FTP is different because obviously we can't distinguish FTP site addresses using regex.