### PR TITLE
Address editing

### DIFF
--- a/src/components/GrampsjsAddresses.js
+++ b/src/components/GrampsjsAddresses.js
@@ -1,117 +1,77 @@
-import {html, LitElement, css} from 'lit'
-import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
-import {sharedStyles} from '../SharedStyles.js'
+import {html} from 'lit'
+import {classMap} from 'lit/directives/class-map.js'
+import {mdiMapMarker} from '@mdi/js'
+
+import {GrampsjsEditableList} from './GrampsjsEditableList.js'
+import './GrampsjsFormEditAddress.js'
+import './GrampsjsIcon.js'
+
+import {dateIsEmpty, fireEvent} from '../util.js'
 import {toDate} from '../date.js'
-import {dateIsEmpty} from '../util.js'
 
-export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
-  static get styles() {
-    return [
-      sharedStyles,
-      css`
-        dl {
-          clear: left;
-        }
+import '@material/web/list/list-item.js'
 
-        dl > div {
-          float: none;
-        }
+// The address properties making up the one-line summary, in display order.
+const summaryFields = [
+  'street',
+  'locality',
+  'city',
+  'county',
+  'state',
+  'postal',
+  'country',
+]
 
-        dl > div > dt {
-          display: inline-block;
-          width: 10em;
-          margin-right: 1em;
-          text-align: right;
-        }
-
-        dl > div > dd {
-          display: inline-block;
-        }
-      `,
-    ]
-  }
-
+export class GrampsjsAddresses extends GrampsjsEditableList {
   static get properties() {
     return {
-      data: {type: Array},
       profile: {type: Array},
     }
   }
 
   constructor() {
     super()
-    this.data = []
     this.profile = []
+    this.hasEdit = true
+    this.objType = 'Address'
   }
 
-  render() {
-    if (this.data.length === 0) {
+  row(obj, i) {
+    return html`
+      <md-list-item
+        type="${this.edit ? 'button' : 'text'}"
+        class="${classMap({selected: i === this._selectedIndex})}"
+        @click="${() => {
+          if (this.edit) {
+            this._handleSelected(i)
+          }
+        }}"
+      >
+        ${summaryFields
+          .map(key => obj[key])
+          .filter(value => value)
+          .join(', ')}
+        ${this._supportingText(obj, i)}
+        <grampsjs-icon
+          slot="start"
+          path="${mdiMapMarker}"
+          color="var(--grampsjs-color-icon)"
+        ></grampsjs-icon>
+      </md-list-item>
+    `
+  }
+
+  // The phone number and the date the address was current, each on its own
+  // line below the address. Omitted entirely when the address has neither.
+  _supportingText(obj, i) {
+    const date = this._dateString(obj, i)
+    if (!obj.phone && !date) {
       return ''
     }
     return html`
-    ${this.data.map(
-      (obj, i) => html`
-        <dl>
-          ${this._dateString(obj, i)
-            ? html`
-                <div>
-                  <dt>${this._('Date')}</dt>
-                  <dd>${this._dateString(obj, i)}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.street
-            ? html`
-                <div>
-                  <dt>${this._('Street')}</dt>
-                  <dd>${obj.street}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.locality
-            ? html`
-                <div>
-                  <dt>${this._('Locality')}</dt>
-                  <dd>${obj.locality}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.city
-            ? html`
-                <div>
-                  <dt>${this._('City')}</dt>
-                  <dd>${obj.city}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.county
-            ? html`
-                <div>
-                  <dt>${this._('County')}</dt>
-                  <dd>${obj.county}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.state
-            ? html`
-                <div>
-                  <dt>${this._('State')}</dt>
-                  <dd>${obj.state}</dd>
-                </div>
-              `
-            : ''}
-          ${obj.country
-            ? html`
-                <div>
-                  <dt>${this._('Country')}</dt>
-                  <dd>${obj.country}</dd>
-                </div>
-              `
-            : ''}
-        </dl>
-      `
-    )}
-      </table>
+      <span slot="supporting-text"
+        >${obj.phone}${obj.phone && date ? html`<br />` : ''}${date}</span
+      >
     `
   }
 
@@ -130,6 +90,67 @@ export class GrampsjsAddresses extends GrampsjsAppStateMixin(LitElement) {
     return obj?.date?.dateval && !dateIsEmpty(obj.date)
       ? toDate(obj.date.dateval)
       : ''
+  }
+
+  _handleAdd() {
+    const data = {_class: 'Address'}
+    this.dialogContent = html`
+      <grampsjs-form-edit-address
+        new
+        dialogTitle="${this._('Address')}"
+        @object:save="${this._handleAddressSave}"
+        @object:cancel="${this._handleDialogCancel}"
+        .appState="${this.appState}"
+        .data="${data}"
+      >
+      </grampsjs-form-edit-address>
+    `
+  }
+
+  _handleEdit() {
+    const data = {...this.data[this._selectedIndex]}
+    this.dialogContent = html`
+      <grampsjs-form-edit-address
+        dialogTitle="${this._('Address')}"
+        @object:save="${this._handleAddressSaveEdit}"
+        @object:cancel="${this._handleDialogCancel}"
+        .appState="${this.appState}"
+        .data="${data}"
+      >
+      </grampsjs-form-edit-address>
+    `
+  }
+
+  _handleDelete() {
+    fireEvent(this, 'edit:action', {
+      action: 'delAddress',
+      index: this._selectedIndex,
+    })
+  }
+
+  _handleAddressSave(e) {
+    fireEvent(this, 'edit:action', {
+      action: 'addAddress',
+      data: e.detail.data,
+    })
+    e.preventDefault()
+    e.stopPropagation()
+    this.dialogContent = ''
+  }
+
+  _handleAddressSaveEdit(e) {
+    fireEvent(this, 'edit:action', {
+      action: 'updateAddress',
+      data: e.detail.data,
+      index: this._selectedIndex,
+    })
+    e.preventDefault()
+    e.stopPropagation()
+    this.dialogContent = ''
+  }
+
+  _handleDialogCancel() {
+    this.dialogContent = ''
   }
 }
 

--- a/src/components/GrampsjsFormEditAddress.js
+++ b/src/components/GrampsjsFormEditAddress.js
@@ -1,0 +1,81 @@
+/*
+Form for editing an address
+*/
+
+import {html} from 'lit'
+
+import './GrampsjsFormString.js'
+import './GrampsjsFormSelectDate.js'
+
+import {GrampsjsObjectForm} from './GrampsjsObjectForm.js'
+import {emptyDate} from '../util.js'
+
+// The address properties edited as plain strings, in display order, with the
+// label used for each. The form field ids are these keys prefixed with
+// `address-` to keep them clear of the ids handled by the base form.
+const stringFields = {
+  street: 'Street',
+  locality: 'Locality',
+  city: 'City',
+  county: 'County',
+  state: 'State',
+  postal: 'Postal Code',
+  country: 'Country',
+  phone: 'Phone',
+}
+
+class GrampsjsFormEditAddress extends GrampsjsObjectForm {
+  renderForm() {
+    return html`
+      ${Object.entries(stringFields).map(
+        ([key, label]) => html`
+          <p>
+            <grampsjs-form-string
+              fullwidth
+              id="address-${key}"
+              @formdata:changed="${this._handleFormData}"
+              label="${this._(label)}"
+              .appState="${this.appState}"
+              value="${this.data?.[key] || ''}"
+            >
+            </grampsjs-form-string>
+          </p>
+        `
+      )}
+      <h4 class="label">${this._('Date')}</h4>
+      <p>
+        <grampsjs-form-select-date
+          @formdata:changed="${this._handleFormData}"
+          fullwidth
+          id="address-date"
+          .data="${this.data?.date ?? emptyDate}"
+          .appState="${this.appState}"
+        >
+        </grampsjs-form-select-date>
+      </p>
+    `
+  }
+
+  get isValid() {
+    const hasContent = Object.keys(stringFields).some(key => this.data?.[key])
+    return hasContent && this._areDateSelectValid()
+  }
+
+  _handleFormData(e) {
+    const originalTarget = e.composedPath()[0]
+    if (originalTarget.id === 'address-date') {
+      this.data = {...this.data, date: e.detail.data ?? emptyDate}
+    } else if (originalTarget.id.startsWith('address-')) {
+      const key = originalTarget.id.slice('address-'.length)
+      if (key in stringFields) {
+        this.data = {...this.data, [key]: e.detail.data}
+      }
+    }
+    super._handleFormData(e)
+  }
+}
+
+window.customElements.define(
+  'grampsjs-form-edit-address',
+  GrampsjsFormEditAddress
+)

--- a/src/components/GrampsjsObject.js
+++ b/src/components/GrampsjsObject.js
@@ -133,7 +133,8 @@ const _allTabs = {
       data?.attribute_list?.length > 0 ||
       data?.urls?.length > 0 ||
       data?.address_list?.length > 0,
-    conditionEdit: data => 'urls' in data || 'attribute_list' in data,
+    conditionEdit: data =>
+      'urls' in data || 'attribute_list' in data || 'address_list' in data,
   },
   associations: {
     title: 'Associations',
@@ -821,12 +822,15 @@ export class GrampsjsObject extends GrampsjsAppStateMixin(LitElement) {
                   attributeCategory="${this._objectsName.toLowerCase()}"
                 ></grampsjs-attributes>`
             : ''}
-          ${this.data.address_list?.length > 0
+          ${this.data.address_list?.length > 0 ||
+          (this.edit && 'address_list' in this.data)
             ? html`<h4>${this._('Addresses')}</h4>
                 <grampsjs-addresses
+                  hasEdit
                   .appState="${this.appState}"
                   .data=${this.data.address_list ?? []}
                   .profile=${this.data?.profile?.addresses ?? []}
+                  ?edit="${this.edit}"
                 ></grampsjs-addresses>`
             : ''}
           ${this.data.urls?.length > 0 || (this.edit && 'urls' in this.data)

--- a/src/views/GrampsjsViewObject.js
+++ b/src/views/GrampsjsViewObject.js
@@ -476,6 +476,8 @@ export class GrampsjsViewObject extends GrampsjsView {
       )
     } else if (e.detail.action === 'addURL') {
       this.addObject(e.detail.data, this._data, this._className, 'urls')
+    } else if (e.detail.action === 'addAddress') {
+      this.addObject(e.detail.data, this._data, this._className, 'address_list')
     } else if (e.detail.action === 'addAssociation') {
       this.addObject(
         e.detail.data,
@@ -542,6 +544,14 @@ export class GrampsjsViewObject extends GrampsjsView {
         this._className,
         'urls'
       )
+    } else if (e.detail.action === 'updateAddress') {
+      this.updateObjectByIndex(
+        e.detail.index,
+        e.detail.data,
+        this._data,
+        this._className,
+        'address_list'
+      )
     } else if (e.detail.action === 'updateAssociation') {
       this.updateObjectByIndex(
         e.detail.index,
@@ -575,6 +585,13 @@ export class GrampsjsViewObject extends GrampsjsView {
       )
     } else if (e.detail.action === 'delURL') {
       this.delObjectByIndex(e.detail.index, this._data, this._className, 'urls')
+    } else if (e.detail.action === 'delAddress') {
+      this.delObjectByIndex(
+        e.detail.index,
+        this._data,
+        this._className,
+        'address_list'
+      )
     } else if (e.detail.action === 'delAssociation') {
       this.delObjectByIndex(
         e.detail.index,

--- a/test/unit/addresses.test.js
+++ b/test/unit/addresses.test.js
@@ -2,7 +2,16 @@ import {describe, it, expect} from 'vitest'
 import {render} from 'lit'
 import {GrampsjsAddresses} from '../../src/components/GrampsjsAddresses.js'
 
-// Render the component and return its rows as [label, value] pairs.
+// The Material list elements call attachInternals() in their constructor,
+// which happy-dom does not implement.
+if (!HTMLElement.prototype.attachInternals) {
+  HTMLElement.prototype.attachInternals = function attachInternals() {
+    return {}
+  }
+}
+
+// Render the component and return one entry per address, holding the summary
+// line and the supporting text below it.
 const renderRows = (data, profile) => {
   const element = new GrampsjsAddresses()
   element.appState = {i18n: {strings: {}}}
@@ -12,10 +21,23 @@ const renderRows = (data, profile) => {
   const shadowRoot = element.createRenderRoot()
   render(element.render(), shadowRoot)
 
-  return [...shadowRoot.querySelectorAll('dl > div')].map(row => [
-    row.querySelector('dt').textContent,
-    row.querySelector('dd').textContent,
-  ])
+  return [...shadowRoot.querySelectorAll('md-list-item')].map(item => ({
+    summary: [...item.childNodes]
+      .filter(node => node.nodeType === Node.TEXT_NODE)
+      .map(node => node.textContent)
+      .join('')
+      .trim(),
+    supporting:
+      item.querySelector('[slot="supporting-text"]')?.textContent.trim() ??
+      null,
+    // The phone and date sit on separate lines, so report them separately.
+    supportingLines: [
+      ...(item.querySelector('[slot="supporting-text"]')?.childNodes ?? []),
+    ]
+      .filter(node => node.nodeType === Node.TEXT_NODE)
+      .map(node => node.textContent.trim())
+      .filter(Boolean),
+  }))
 }
 
 const date = dateval => ({
@@ -28,24 +50,59 @@ const date = dateval => ({
   text: '',
 })
 
+describe('address summary', () => {
+  it('lists every location field of a fully populated address', () => {
+    const rows = renderRows(
+      [
+        {
+          street: '12 High Street',
+          locality: 'Oldtown',
+          city: 'Cambridge',
+          county: 'Cambridgeshire',
+          state: 'England',
+          postal: 'CB1 1AA',
+          country: 'United Kingdom',
+        },
+      ],
+      []
+    )
+    expect(rows[0].summary).to.equal(
+      '12 High Street, Oldtown, Cambridge, Cambridgeshire, England, CB1 1AA, United Kingdom'
+    )
+  })
+
+  it('omits the fields an address leaves empty', () => {
+    const rows = renderRows([{street: 'High Street', country: 'Germany'}], [])
+    expect(rows[0].summary).to.equal('High Street, Germany')
+  })
+
+  it('renders one row per address', () => {
+    const rows = renderRows(
+      [{street: 'High Street'}, {street: 'Mill Lane'}],
+      []
+    )
+    expect(rows.map(row => row.summary)).to.deep.equal([
+      'High Street',
+      'Mill Lane',
+    ])
+  })
+})
+
 describe('address dates', () => {
   it('shows the date string supplied by the profile', () => {
     const rows = renderRows(
       [{street: 'High Street'}],
       [{date_str: '1990-03-15'}]
     )
-    expect(rows).to.deep.equal([
-      ['Date', '1990-03-15'],
-      ['Street', 'High Street'],
-    ])
+    expect(rows[0].supporting).to.equal('1990-03-15')
   })
 
-  it('omits the date row for an address the profile reports as undated', () => {
+  it('shows no date for an address the profile reports as undated', () => {
     const rows = renderRows(
       [{street: 'High Street', date: date([2, 1, 2000, false])}],
       [{date_str: ''}]
     )
-    expect(rows).to.deep.equal([['Street', 'High Street']])
+    expect(rows[0].supporting).to.equal(null)
   })
 
   it('takes the date of each address from the profile entry of the same index', () => {
@@ -53,12 +110,7 @@ describe('address dates', () => {
       [{street: 'High Street'}, {street: 'Mill Lane'}],
       [{date_str: '1850'}, {date_str: '1860'}]
     )
-    expect(rows).to.deep.equal([
-      ['Date', '1850'],
-      ['Street', 'High Street'],
-      ['Date', '1860'],
-      ['Street', 'Mill Lane'],
-    ])
+    expect(rows.map(row => row.supporting)).to.deep.equal(['1850', '1860'])
   })
 
   // Every object type with addresses formats their dates in its profile, so
@@ -69,23 +121,48 @@ describe('address dates', () => {
         [{street: 'High Street', date: date([2, 1, 2000, false])}],
         []
       )
-      expect(rows).to.deep.equal([
-        ['Date', '2000-1-2'],
-        ['Street', 'High Street'],
-      ])
+      expect(rows[0].supporting).to.equal('2000-1-2')
     })
 
-    it('omits the date row for an address with no date at all', () => {
+    it('shows no date for an address with no date at all', () => {
       const rows = renderRows([{street: 'High Street'}], [])
-      expect(rows).to.deep.equal([['Street', 'High Street']])
+      expect(rows[0].supporting).to.equal(null)
     })
 
-    it('omits the date row for an address holding an empty date', () => {
+    it('shows no date for an address holding an empty date', () => {
       const rows = renderRows(
         [{street: 'High Street', date: date([0, 0, 0, false])}],
         []
       )
-      expect(rows).to.deep.equal([['Street', 'High Street']])
+      expect(rows[0].supporting).to.equal(null)
     })
+  })
+})
+
+describe('address phone number', () => {
+  it('puts the phone number and the date on separate lines', () => {
+    const rows = renderRows(
+      [{street: 'High Street', phone: '01223 123456'}],
+      [{date_str: '1850'}]
+    )
+    expect(rows[0].supportingLines).to.deep.equal(['01223 123456', '1850'])
+  })
+
+  it('shows the phone number on its own for an undated address', () => {
+    const rows = renderRows(
+      [{street: 'High Street', phone: '01223 123456'}],
+      [{date_str: ''}]
+    )
+    expect(rows[0].supportingLines).to.deep.equal(['01223 123456'])
+  })
+
+  it('shows the date on its own for an address with no phone number', () => {
+    const rows = renderRows([{street: 'High Street'}], [{date_str: '1850'}])
+    expect(rows[0].supportingLines).to.deep.equal(['1850'])
+  })
+
+  it('omits the supporting text when there is neither phone nor date', () => {
+    const rows = renderRows([{street: 'High Street'}], [{date_str: ''}])
+    expect(rows[0].supporting).to.equal(null)
   })
 })


### PR DESCRIPTION
Relates to #36. This is based on #1352, to avoid conflicts. 2 of the 5 commits are from that PR.

I'm hoping to use Gramps Web in place of Gramps for my family, and keeping addresses is one of things we do. I've chosen a really simple implementation, which includes a proposal to change the way addresses are rendered; making them render more like the other editable types. I am of course happy to make changes to suit your direction.

<img width="556" height="175" alt="image" src="https://github.com/user-attachments/assets/2746a895-5473-48b5-a1a4-9b7b9a44b630" />

And with a date:
<img width="548" height="185" alt="image" src="https://github.com/user-attachments/assets/fc5f7a72-12b9-4eb0-a33f-ac23043b911a" />

Editing:
<img width="645" height="211" alt="image" src="https://github.com/user-attachments/assets/0f1adcf3-e611-4773-ab62-bbcff9e1149d" />

Editing modal:
<img width="490" height="789" alt="image" src="https://github.com/user-attachments/assets/1df7e391-b340-4b39-9956-c3a3aefbe022" />
<img width="492" height="303" alt="image" src="https://github.com/user-attachments/assets/dd756839-6876-48ca-adc7-9a0caadc58df" />
