### PR TITLE
Replace `mwc-select` with `md-select` so dropdowns escape dialog clipping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@material/mwc-linear-progress": "^0.27.0",
         "@material/mwc-list": "^0.27.0",
         "@material/mwc-menu": "^0.27.0",
-        "@material/mwc-select": "^0.27.0",
         "@material/mwc-snackbar": "^0.27.0",
         "@material/mwc-textfield": "^0.27.0",
         "@material/mwc-top-app-bar": "^0.27.0",
@@ -3630,63 +3629,6 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
-    "node_modules/@material/mwc-select": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-select/-/mwc-select-0.27.0.tgz",
-      "integrity": "sha512-LTr2nl7gAYq8ung4eWfUz24mey4/K9vAlqJBo/uu6w0122C9X64szBS9kHAb87aD1oxLkxAJCDuv/wwlXV1i2w==",
-      "dependencies": {
-        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
-        "@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
-        "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
-        "@material/list": "=14.0.0-canary.53b3cad2f.0",
-        "@material/mwc-base": "^0.27.0",
-        "@material/mwc-floating-label": "^0.27.0",
-        "@material/mwc-icon": "^0.27.0",
-        "@material/mwc-line-ripple": "^0.27.0",
-        "@material/mwc-list": "^0.27.0",
-        "@material/mwc-menu": "^0.27.0",
-        "@material/mwc-notched-outline": "^0.27.0",
-        "@material/select": "=14.0.0-canary.53b3cad2f.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-select/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-select/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-select/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-select/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-snackbar": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-snackbar/-/mwc-snackbar-0.27.0.tgz",
@@ -3892,32 +3834,6 @@
       "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
       "dependencies": {
         "@material/theme": "14.0.0-canary.53b3cad2f.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/select": {
-      "version": "14.0.0-canary.53b3cad2f.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0-canary.53b3cad2f.0.tgz",
-      "integrity": "sha512-fAiTaHZ1PIEmCUbufS+IZvsWO0hDxtbU8rOsbmSu1oupAboP7jSgOVgcCGdT9KY5WacrniIIMO6jZjhnvrC0Lg==",
-      "dependencies": {
-        "@material/animation": "14.0.0-canary.53b3cad2f.0",
-        "@material/base": "14.0.0-canary.53b3cad2f.0",
-        "@material/density": "14.0.0-canary.53b3cad2f.0",
-        "@material/dom": "14.0.0-canary.53b3cad2f.0",
-        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
-        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
-        "@material/floating-label": "14.0.0-canary.53b3cad2f.0",
-        "@material/line-ripple": "14.0.0-canary.53b3cad2f.0",
-        "@material/list": "14.0.0-canary.53b3cad2f.0",
-        "@material/menu": "14.0.0-canary.53b3cad2f.0",
-        "@material/menu-surface": "14.0.0-canary.53b3cad2f.0",
-        "@material/notched-outline": "14.0.0-canary.53b3cad2f.0",
-        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
-        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
-        "@material/shape": "14.0.0-canary.53b3cad2f.0",
-        "@material/theme": "14.0.0-canary.53b3cad2f.0",
-        "@material/tokens": "14.0.0-canary.53b3cad2f.0",
-        "@material/typography": "14.0.0-canary.53b3cad2f.0",
         "tslib": "^2.1.0"
       }
     },
@@ -17859,65 +17775,6 @@
         }
       }
     },
-    "@material/mwc-select": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@material/mwc-select/-/mwc-select-0.27.0.tgz",
-      "integrity": "sha512-LTr2nl7gAYq8ung4eWfUz24mey4/K9vAlqJBo/uu6w0122C9X64szBS9kHAb87aD1oxLkxAJCDuv/wwlXV1i2w==",
-      "requires": {
-        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
-        "@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
-        "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
-        "@material/list": "=14.0.0-canary.53b3cad2f.0",
-        "@material/mwc-base": "^0.27.0",
-        "@material/mwc-floating-label": "^0.27.0",
-        "@material/mwc-icon": "^0.27.0",
-        "@material/mwc-line-ripple": "^0.27.0",
-        "@material/mwc-list": "^0.27.0",
-        "@material/mwc-menu": "^0.27.0",
-        "@material/mwc-notched-outline": "^0.27.0",
-        "@material/select": "=14.0.0-canary.53b3cad2f.0",
-        "lit": "^2.0.0",
-        "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "@lit/reactive-element": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-          "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.0.0"
-          }
-        },
-        "lit": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-          "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-          "requires": {
-            "@lit/reactive-element": "^1.6.0",
-            "lit-element": "^3.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-element": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.1.0",
-            "@lit/reactive-element": "^1.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-html": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-          "requires": {
-            "@types/trusted-types": "^2.0.2"
-          }
-        }
-      }
-    },
     "@material/mwc-snackbar": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-snackbar/-/mwc-snackbar-0.27.0.tgz",
@@ -18129,32 +17986,6 @@
       "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
       "requires": {
         "@material/theme": "14.0.0-canary.53b3cad2f.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/select": {
-      "version": "14.0.0-canary.53b3cad2f.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0-canary.53b3cad2f.0.tgz",
-      "integrity": "sha512-fAiTaHZ1PIEmCUbufS+IZvsWO0hDxtbU8rOsbmSu1oupAboP7jSgOVgcCGdT9KY5WacrniIIMO6jZjhnvrC0Lg==",
-      "requires": {
-        "@material/animation": "14.0.0-canary.53b3cad2f.0",
-        "@material/base": "14.0.0-canary.53b3cad2f.0",
-        "@material/density": "14.0.0-canary.53b3cad2f.0",
-        "@material/dom": "14.0.0-canary.53b3cad2f.0",
-        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
-        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
-        "@material/floating-label": "14.0.0-canary.53b3cad2f.0",
-        "@material/line-ripple": "14.0.0-canary.53b3cad2f.0",
-        "@material/list": "14.0.0-canary.53b3cad2f.0",
-        "@material/menu": "14.0.0-canary.53b3cad2f.0",
-        "@material/menu-surface": "14.0.0-canary.53b3cad2f.0",
-        "@material/notched-outline": "14.0.0-canary.53b3cad2f.0",
-        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
-        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
-        "@material/shape": "14.0.0-canary.53b3cad2f.0",
-        "@material/theme": "14.0.0-canary.53b3cad2f.0",
-        "@material/tokens": "14.0.0-canary.53b3cad2f.0",
-        "@material/typography": "14.0.0-canary.53b3cad2f.0",
         "tslib": "^2.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "@material/mwc-linear-progress": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
     "@material/mwc-menu": "^0.27.0",
-    "@material/mwc-select": "^0.27.0",
     "@material/mwc-snackbar": "^0.27.0",
     "@material/mwc-textfield": "^0.27.0",
     "@material/mwc-top-app-bar": "^0.27.0",

--- a/src/components/GrampsjsFormEditCitationDetails.js
+++ b/src/components/GrampsjsFormEditCitationDetails.js
@@ -4,6 +4,9 @@ Form for adding a new event reference
 
 import {html} from 'lit'
 
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
+
 import './GrampsjsFormSelectDate.js'
 import './GrampsjsFormSelectObjectList.js'
 
@@ -63,24 +66,24 @@ class GrampsjsFormEditCitationDetails extends GrampsjsObjectForm {
       </p>
 
       <h4 class="label">${this._('Confidence')}</h4>
-      <mwc-select
+      <md-filled-select
         id="select-confidence"
         @change="${this.handleConfidence}"
-        fixedMenuPosition
       >
         ${Object.keys(confidence).map(
           conf => html`
-            <mwc-list-item
+            <md-select-option
               value="${conf}"
               ?selected="${
                 // eslint-disable-next-line eqeqeq
                 conf == this.data.confidence
               }"
-              >${this._(confidence[conf])}</mwc-list-item
             >
+              <div slot="headline">${this._(confidence[conf])}</div>
+            </md-select-option>
           `
         )}
-      </mwc-select>
+      </md-filled-select>
     `
   }
 

--- a/src/components/GrampsjsFormNewCitation.js
+++ b/src/components/GrampsjsFormNewCitation.js
@@ -5,6 +5,8 @@ Form for adding a new event reference
 import {html} from 'lit'
 import '@material/mwc-textfield'
 import '@material/mwc-button'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import './GrampsjsFormSelectType.js'
 import './GrampsjsFormSelectObjectList.js'
@@ -48,24 +50,24 @@ class GrampsjsFormNewCitation extends GrampsjsObjectForm {
       </p>
 
       <h4 class="label">${this._('Confidence')}</h4>
-      <mwc-select
+      <md-filled-select
         id="select-confidence"
         @change="${this.handleConfidence}"
-        fixedMenuPosition
       >
         ${Object.keys(confidence).map(
           conf => html`
-            <mwc-list-item
+            <md-select-option
               value="${conf}"
               ?selected="${
                 // eslint-disable-next-line eqeqeq
                 conf == this.data.confidence
               }"
-              >${this._(confidence[conf])}</mwc-list-item
             >
+              <div slot="headline">${this._(confidence[conf])}</div>
+            </md-select-option>
           `
         )}
-      </mwc-select>
+      </md-filled-select>
 
       <div class="spacer"></div>
       <grampsjs-form-private

--- a/src/components/GrampsjsFormSelectDate.js
+++ b/src/components/GrampsjsFormSelectDate.js
@@ -4,9 +4,9 @@ Element for selecting a Gramps type
 
 import {html, css, LitElement} from 'lit'
 import '@material/mwc-textfield'
-import '@material/mwc-select'
-import '@material/mwc-list/mwc-list-item'
 import '@material/web/iconbutton/icon-button.js'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import {mdiCalendar} from '@mdi/js'
 
@@ -68,8 +68,16 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
           white-space: nowrap;
         }
 
-        span.dateform mwc-textfield {
+        span.dateform mwc-textfield,
+        span.dateform md-filled-select {
           margin-bottom: 10px;
+        }
+
+        /* md-filled-select defaults to min-width: 210px, which would blow out
+           the narrow month and day fields. */
+        md-filled-select.narrow {
+          width: 7em;
+          min-width: 6em;
         }
       `,
     ]
@@ -91,45 +99,45 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
   render() {
     return html`
     <p>
-      <mwc-select
+      <md-filled-select
         id="select-modifier"
         label="${this._('Type')}"
         @change="${this.handleType}"
-        fixedMenuPosition
       >
         ${Object.keys(modifiers).map(
           modifier => html`
-            <mwc-list-item
+            <md-select-option
               value="${modifier}"
               ?selected="${
                 // eslint-disable-next-line eqeqeq
                 modifier == (this.data.modifier || 0)
               }"
-              >${this._(modifiers[modifier])}</mwc-list-item
             >
+              <div slot="headline">${this._(modifiers[modifier])}</div>
+            </md-select-option>
           `
         )}
-      </mwc-select>
+      </md-filled-select>
 
-      <mwc-select
+      <md-filled-select
         id="select-quality"
         label="${this._('Quality')}"
         @change="${this.handleQuality}"
-        fixedMenuPosition
       >
         ${Object.keys(qualifiers).map(
           qualifier => html`
-            <mwc-list-item
+            <md-select-option
               value="${qualifier}"
               ?selected="${
                 // eslint-disable-next-line eqeqeq
                 qualifier == (this.data.quality || 0)
               }"
-              >${this._(qualifiers[qualifier])}</mwc-list-item
             >
+              <div slot="headline">${this._(qualifiers[qualifier])}</div>
+            </md-select-option>
           `
         )}
-      </mwc-select>
+      </md-filled-select>
     </p>
     <p>
     <span class="dateform">
@@ -141,46 +149,44 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         style="width: 6em;"
         value="${this.data.dateval[2] || ''}"
       ></mwc-textfield>
-      <mwc-select
+      <md-filled-select
         @change="${this.handleMonth1}"
         id="month1"
         label="${this._('Month')}"
-        style="width: 6em;"
-        fixedMenuPosition
+        class="narrow"
       >${[...Array(13).keys()].map(
         idx => html`
-          <mwc-list-item
+          <md-select-option
             value="${idx}"
             ?selected="${
               // eslint-disable-next-line eqeqeq
               idx == (this.data.dateval[1] || 0)
             }"
           >
-            ${idx === 0 ? '' : idx}
-          </mwc-list-item>
+            <div slot="headline">${idx === 0 ? '' : idx}</div>
+          </md-select-option>
         `
       )}
-      </mwc-select>
-      <mwc-select
+      </md-filled-select>
+      <md-filled-select
         @change="${this.handleDay1}"
         id="day1"
         label="${this._('Day')}"
-        style="width: 6em;"
-        fixedMenuPosition
+        class="narrow"
       >${[...Array(32).keys()].map(
         idx => html`
-          <mwc-list-item
+          <md-select-option
             value="${idx}"
             ?selected="${
               // eslint-disable-next-line eqeqeq
               idx == (this.data.dateval[0] || 0)
             }"
           >
-            ${idx === 0 ? '' : idx}
-          </mwc-list-item>
+            <div slot="headline">${idx === 0 ? '' : idx}</div>
+          </md-select-option>
         `
       )}
-      </mwc-select>
+      </md-filled-select>
 
       <input
         type="date"
@@ -213,46 +219,44 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
         style="width: 6em;"
         value="${this.data.dateval[6] || ''}"
       ></mwc-textfield>
-      <mwc-select
+      <md-filled-select
         @change="${this.handleMonth2}"
         id="month2"
         label="${this._('Month')}"
-        style="width: 6em;"
-        fixedMenuPosition
+        class="narrow"
       >${[...Array(13).keys()].map(
         idx => html`
-          <mwc-list-item
+          <md-select-option
             value="${idx}"
             ?selected="${
               // eslint-disable-next-line eqeqeq
               idx == (this.data.dateval[5] || 0)
             }"
           >
-            ${idx === 0 ? '' : idx}
-          </mwc-list-item>
+            <div slot="headline">${idx === 0 ? '' : idx}</div>
+          </md-select-option>
         `
       )}
-      </mwc-select>
-      <mwc-select
+      </md-filled-select>
+      <md-filled-select
         @change="${this.handleDay2}"
         id="day2"
         label="${this._('Day')}"
-        style="width: 6em;"
-        fixedMenuPosition
+        class="narrow"
       >${[...Array(32).keys()].map(
         idx => html`
-          <mwc-list-item
+          <md-select-option
             value="${idx}"
             ?selected="${
               // eslint-disable-next-line eqeqeq
               idx == (this.data.dateval[4] || 0)
             }"
           >
-            ${idx === 0 ? '' : idx}
-          </mwc-list-item>
+            <div slot="headline">${idx === 0 ? '' : idx}</div>
+          </md-select-option>
         `
       )}
-      </mwc-select>
+      </md-filled-select>
 
       <input
         type="date"
@@ -288,9 +292,9 @@ class GrampsjsFormSelectDate extends GrampsjsAppStateMixin(LitElement) {
       // eslint-disable-next-line no-param-reassign
       element.value = ''
     })
-    this.shadowRoot.querySelectorAll('mwc-select').forEach(element => {
+    this.shadowRoot.querySelectorAll('md-filled-select').forEach(element => {
       // eslint-disable-next-line no-param-reassign
-      element.value = 0
+      element.value = '0'
     })
   }
 

--- a/src/components/GrampsjsFormUser.js
+++ b/src/components/GrampsjsFormUser.js
@@ -4,6 +4,8 @@ Element for selecting a Gramps type
 
 import {html, css, LitElement} from 'lit'
 import '@material/mwc-textfield'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import {sharedStyles} from '../SharedStyles.js'
 import './GrampsjsFormString.js'
@@ -19,6 +21,8 @@ export const userRoles = {
   4: 'Owner',
   5: 'Administrator',
 }
+
+const defaultRole = 0
 
 class GrampsjsFormUser extends GrampsjsAppStateMixin(LitElement) {
   static get styles() {
@@ -47,7 +51,7 @@ class GrampsjsFormUser extends GrampsjsAppStateMixin(LitElement) {
 
   constructor() {
     super()
-    this.data = {}
+    this.data = {role: defaultRole}
     this.ismulti = false
     this.isFormValid = false
     this.newUser = false
@@ -103,9 +107,8 @@ class GrampsjsFormUser extends GrampsjsAppStateMixin(LitElement) {
         ></grampsjs-form-string>
       </p>
       <p>
-        <mwc-select
-          fixedMenuPosition
-          @selected="${this._handleRoleChange}"
+        <md-filled-select
+          @change="${this._handleRoleChange}"
           id="role"
           style="width: 100%;"
         >
@@ -115,16 +118,15 @@ class GrampsjsFormUser extends GrampsjsAppStateMixin(LitElement) {
             .filter(x => x <= 4 || this.ismulti)
             .map(
               role => html`
-                <mwc-list-item
+                <md-select-option
                   value="${role}"
-                  ?selected="${this.data.role === undefined
-                    ? role === 0
-                    : role === this.data.role}"
-                  >${this._(userRoles[role])}
-                </mwc-list-item>
+                  ?selected="${role === (this.data.role ?? defaultRole)}"
+                >
+                  <div slot="headline">${this._(userRoles[role])}</div>
+                </md-select-option>
               `
             )}
-        </mwc-select>
+        </md-filled-select>
       </p>
     `
   }
@@ -143,11 +145,7 @@ class GrampsjsFormUser extends GrampsjsAppStateMixin(LitElement) {
   }
 
   _handleRoleChange(e) {
-    const i = e.detail.index
-    const roleKeys = Object.keys(userRoles)
-      .map(Number)
-      .sort((a, b) => a - b)
-    const role = roleKeys[i]
+    const role = parseInt(e.target.value, 10)
     this.data = {...this.data, role}
     this._checkFormValid()
   }

--- a/src/components/GrampsjsReportOptions.js
+++ b/src/components/GrampsjsReportOptions.js
@@ -1,7 +1,7 @@
 import {LitElement, css, html} from 'lit'
-import '@material/mwc-select'
 import '@material/mwc-textfield'
-import '@material/mwc-list/mwc-list-item'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 import '@material/web/switch/switch'
 
 import {sharedStyles} from '../SharedStyles.js'
@@ -38,7 +38,7 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
         }
 
         mwc-textfield,
-        mwc-select {
+        md-filled-select {
           min-width: 20em;
           max-width: 100%;
         }
@@ -133,11 +133,11 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
       <div class="option">
         <span class="label">${this._(this.optionsHelp[key][1]) || key}</span>
         <span class="form">
-          <mwc-select id="${key}" @change="${this._handleSelect}">
+          <md-filled-select id="${key}" @change="${this._handleSelect}">
             ${this.optionsHelp[key][2].map(item =>
               this._renderSelectItem(item, this.optionsDict[key])
             )}
-          </mwc-select>
+          </md-filled-select>
         </span>
       </div>
     `
@@ -169,9 +169,9 @@ export class GrampsjsReportOptions extends GrampsjsAppStateMixin(LitElement) {
     const selected = itemValue === `${value}` || itemValue === 'pdf'
     const label = reportSelectItemLabel(key, item => this._(item))
     return html`
-      <mwc-list-item value="${itemValue}" ?selected=${selected}
-        >${label}</mwc-list-item
-      >
+      <md-select-option value="${itemValue}" ?selected=${selected}>
+        <div slot="headline">${label}</div>
+      </md-select-option>
     `
   }
 

--- a/src/components/GrampsjsTask.js
+++ b/src/components/GrampsjsTask.js
@@ -11,10 +11,9 @@ import {
 import {sharedStyles} from '../SharedStyles.js'
 
 import '@material/mwc-button'
-import '@material/mwc-select'
-import '@material/mwc-list'
-import '@material/mwc-list/mwc-list-item'
 import '@material/web/iconbutton/icon-button.js'
+import '@material/web/select/outlined-select.js'
+import '@material/web/select/select-option.js'
 
 import './GrampsjsEditor.js'
 import './GrampsjsIcon.js'
@@ -46,16 +45,25 @@ export class GrampsjsTask extends GrampsjsAppStateMixin(LitElement) {
 
         .dropdowns {
           margin-top: 48px;
-          --mdc-select-outlined-disabled-border-color: var(
+          --md-outlined-select-text-field-disabled-outline-color: var(
             --grampsjs-body-font-color-38
           );
-          --mdc-select-disabled-ink-color: var(--grampsjs-body-font-color-87);
-          --mdc-select-disabled-dropdown-icon-color: var(
+          --md-outlined-select-text-field-disabled-outline-opacity: 1;
+          --md-outlined-select-text-field-disabled-input-text-color: var(
+            --grampsjs-body-font-color-87
+          );
+          --md-outlined-select-text-field-disabled-input-text-opacity: 1;
+          --md-outlined-select-text-field-disabled-label-text-color: var(
+            --grampsjs-body-font-color-87
+          );
+          --md-outlined-select-text-field-disabled-label-text-opacity: 1;
+          --md-outlined-select-text-field-disabled-trailing-icon-color: var(
             --grampsjs-color-shade-255
           );
+          --md-outlined-select-text-field-disabled-trailing-icon-opacity: 1;
         }
 
-        .dropdowns mwc-select {
+        .dropdowns md-outlined-select {
           margin-right: 12px;
           margin-bottom: 18px;
         }
@@ -122,8 +130,7 @@ export class GrampsjsTask extends GrampsjsAppStateMixin(LitElement) {
       </h2>
 
       <p class="dropdowns">
-        <mwc-select
-          outlined
+        <md-outlined-select
           ?disabled="${!this.canEdit}"
           label="${this._('Status')}"
           id="select-status"
@@ -131,31 +138,31 @@ export class GrampsjsTask extends GrampsjsAppStateMixin(LitElement) {
         >
           ${['Open', 'In Progress', 'Blocked', 'Done'].map(
             status => html`
-              <mwc-list-item
+              <md-select-option
                 value="${status}"
                 ?selected="${this._status === status}"
-                >${this._(status)}</mwc-list-item
               >
+                <div slot="headline">${this._(status)}</div>
+              </md-select-option>
             `
           )}
-        </mwc-select>
-        <mwc-select
-          outlined
+        </md-outlined-select>
+        <md-outlined-select
           ?disabled="${!this.canEdit}"
           label="${this._('Priority')}"
           id="select-priority"
           @change="${this._handlePrioChange}"
         >
-          <mwc-list-item value="1" ?selected="${this._priority < 5}"
-            >${this._('High')}</mwc-list-item
-          >
-          <mwc-list-item value="5" ?selected="${this._priority === '5'}"
-            >${this._('Medium')}</mwc-list-item
-          >
-          <mwc-list-item value="9" ?selected="${this._priority > 5}"
-            >${this._('Low')}</mwc-list-item
-          >
-        </mwc-select>
+          <md-select-option value="1" ?selected="${this._priority < 5}">
+            <span slot="headline">${this._('High')}</span>
+          </md-select-option>
+          <md-select-option value="5" ?selected="${this._priority === '5'}">
+            <span slot="headline">${this._('Medium')}</span>
+          </md-select-option>
+          <md-select-option value="9" ?selected="${this._priority > 5}">
+            <span slot="headline">${this._('Low')}</span>
+          </md-select-option>
+        </md-outlined-select>
       </p>
 
       <h3>${this._('Description')}</h3>

--- a/src/components/GrampsjsTextRecognition.js
+++ b/src/components/GrampsjsTextRecognition.js
@@ -1,4 +1,8 @@
 import {html, LitElement, css} from 'lit'
+
+import '@material/web/select/outlined-select.js'
+import '@material/web/select/select-option.js'
+
 import {GrampsjsAppStateMixin} from '../mixins/GrampsjsAppStateMixin.js'
 import {sharedStyles} from '../SharedStyles.js'
 
@@ -219,21 +223,21 @@ export class GrampsjsTextRecognition extends GrampsjsAppStateMixin(LitElement) {
   render() {
     return html`
       <p>
-        <mwc-select
-          outlined
+        <md-outlined-select
           label="${this._('Language')}"
           @change="${this._handleLangChange}"
         >
           ${this.languages.map(
             lang => html`
-              <mwc-list-item
+              <md-select-option
                 value="${lang}"
                 ?selected=${lang === this.options.lang}
-                >${tesseractLanguages[lang] || lang}</mwc-list-item
               >
+                <div slot="headline">${tesseractLanguages[lang] || lang}</div>
+              </md-select-option>
             `
           )}
-        </mwc-select>
+        </md-outlined-select>
       </p>
       <p>
         <mwc-button

--- a/src/mixins/GrampsjsNewPersonMixin.js
+++ b/src/mixins/GrampsjsNewPersonMixin.js
@@ -33,7 +33,7 @@ export const GrampsjsNewPersonMixin = superClass =>
         ></grampsjs-form-name>
 
         <h4 class="label">${this._('Gender')}</h4>
-        <md-filled-select id="select-confidence" @change="${this.handleGender}">
+        <md-filled-select id="select-gender" @change="${this.handleGender}">
           ${Object.keys(this.gender).map(
             genderConst => html`
               <md-select-option

--- a/src/mixins/GrampsjsNewPersonMixin.js
+++ b/src/mixins/GrampsjsNewPersonMixin.js
@@ -1,5 +1,8 @@
 import {html} from 'lit'
 
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
+
 import {makeHandle, dateIsEmpty, emptyDate} from '../util.js'
 
 import '../components/GrampsjsFormSelectObjectList.js'
@@ -30,20 +33,21 @@ export const GrampsjsNewPersonMixin = superClass =>
         ></grampsjs-form-name>
 
         <h4 class="label">${this._('Gender')}</h4>
-        <mwc-select id="select-confidence" @change="${this.handleGender}">
+        <md-filled-select id="select-confidence" @change="${this.handleGender}">
           ${Object.keys(this.gender).map(
             genderConst => html`
-              <mwc-list-item
+              <md-select-option
                 value="${genderConst}"
                 ?selected="${
                   // eslint-disable-next-line eqeqeq
                   genderConst == this.data.gender
                 }"
-                >${this._(this.gender[genderConst])}</mwc-list-item
               >
+                <div slot="headline">${this._(this.gender[genderConst])}</div>
+              </md-select-option>
             `
           )}
-        </mwc-select>
+        </md-filled-select>
 
         <h4 class="label">${this._('Birth Date')}</h4>
 

--- a/src/views/GrampsjsViewNewCitation.js
+++ b/src/views/GrampsjsViewNewCitation.js
@@ -1,6 +1,8 @@
 import {html} from 'lit'
 
 import '@material/mwc-textfield'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import {GrampsjsViewNewObject} from './GrampsjsViewNewObject.js'
 import '../components/GrampsjsFormString.js'
@@ -47,20 +49,24 @@ export class GrampsjsViewNewCitation extends GrampsjsViewNewObject {
       </p>
 
       <h4 class="label">${this._('Confidence')}</h4>
-      <mwc-select id="select-confidence" @change="${this.handleConfidence}">
+      <md-filled-select
+        id="select-confidence"
+        @change="${this.handleConfidence}"
+      >
         ${Object.keys(confidence).map(
           conf => html`
-            <mwc-list-item
+            <md-select-option
               value="${conf}"
               ?selected="${
                 // eslint-disable-next-line eqeqeq
                 conf == this.data.confidence
               }"
-              >${this._(confidence[conf])}</mwc-list-item
             >
+              <div slot="headline">${this._(confidence[conf])}</div>
+            </md-select-option>
           `
         )}
-      </mwc-select>
+      </md-filled-select>
 
       ${this._renderTagsForm()}
 

--- a/src/views/GrampsjsViewNewObject.js
+++ b/src/views/GrampsjsViewNewObject.js
@@ -1,7 +1,5 @@
 import {html, css} from 'lit'
 
-import '@material/mwc-select'
-import '@material/mwc-list/mwc-list-item'
 import '@material/web/button/outlined-button.js'
 import '@material/web/button/filled-button.js'
 

--- a/src/views/GrampsjsViewNewRepository.js
+++ b/src/views/GrampsjsViewNewRepository.js
@@ -1,7 +1,5 @@
 import {html} from 'lit'
 
-import '@material/mwc-select'
-import '@material/mwc-list/mwc-list-item'
 import '@material/mwc-textfield'
 import '@material/mwc-button'
 import '@material/mwc-circular-progress'

--- a/src/views/GrampsjsViewNewTask.js
+++ b/src/views/GrampsjsViewNewTask.js
@@ -1,7 +1,8 @@
 import {html} from 'lit'
 
 import '@material/mwc-textfield'
-import '@material/mwc-select'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import '../components/GrampsjsEditor.js'
 import '../components/GrampsjsFormString.js'
@@ -60,17 +61,17 @@ export class GrampsjsViewNewTask extends GrampsjsViewNewSource {
 
       <h4 class="label">${this._('Priority')}</h4>
       <p>
-        <mwc-select @change="${this.handlePriority}">
-          <mwc-list-item ?selected="${priority < 4}" value="1"
-            >${this._('High')}</mwc-list-item
-          >
-          <mwc-list-item ?selected="${priority === '5'}" value="5"
-            >${this._('Medium')}</mwc-list-item
-          >
-          <mwc-list-item ?selected="${priority > 5}" value="9"
-            >${this._('Low')}</mwc-list-item
-          >
-        </mwc-select>
+        <md-filled-select @change="${this.handlePriority}">
+          <md-select-option ?selected="${priority < 4}" value="1">
+            <span slot="headline">${this._('High')}</span>
+          </md-select-option>
+          <md-select-option ?selected="${priority === '5'}" value="5">
+            <span slot="headline">${this._('Medium')}</span>
+          </md-select-option>
+          <md-select-option ?selected="${priority > 5}" value="9">
+            <span slot="headline">${this._('Low')}</span>
+          </md-select-option>
+        </md-filled-select>
       </p>
 
       ${this._renderTagsForm()}

--- a/src/views/GrampsjsViewTreeChartBase.js
+++ b/src/views/GrampsjsViewTreeChartBase.js
@@ -6,6 +6,8 @@ import '@material/web/dialog/dialog.js'
 import '@material/web/button/text-button.js'
 import '@material/web/fab/fab.js'
 import '@material/web/iconbutton/icon-button.js'
+import '@material/web/select/filled-select.js'
+import '@material/web/select/select-option.js'
 
 import {
   mdiAccountDetails,
@@ -318,20 +320,20 @@ export class GrampsjsViewTreeChartBase extends GrampsjsStaleDataMixin(
               <tr>
                 <td>${this._('Name Display Format')}</td>
                 <td>
-                    <mwc-select
-                      fixedMenuPosition
+                    <md-filled-select
                       id="name-display-format"
                       @change=${this._handleChangeNameDisplayFormat}
                     >
                       ${map(
                         Object.values(chartNameDisplayFormat),
-                        i => html` <mwc-list-item
+                        i => html` <md-select-option
                           value="${i}"
                           ?selected="${i === this.nameDisplayFormat}"
-                          >${this._(i)}</mwc-list-item
-                        >`
+                        >
+                          <div slot="headline">${this._(i)}</div>
+                        </md-select-option>`
                       )}
-                    </mwc-select>
+                    </md-filled-select>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
## Linked issue

Closes #1363

## What this changes

`mwc-select` renders its menu inside its own shadow root, so in Safari the menu is clipped by `md-dialog`'s `.container` (`overflow: hidden` plus `border-radius`) even with `fixedMenuPosition` set. `md-select` defaults to `menu-positioning="popover"`, which puts the menu in the top layer where no ancestor can clip it.

The PR converts all `mwc-select` instances to `md-filled-select`/`md-outlined-select` with `md-select-option`. Some of the surrounding code is changed, such as the default role in the user form, as part of the conversion.

## How it was tested

I went through each page that used these components and tested them—using Safari and Chrome on macOS. I did more careful testing where logic around the components changed (user form) and element types (tasks).

### New user form:
<img width="356" height="593" alt="image" src="https://github.com/user-attachments/assets/e7188210-b470-4eb7-b2f6-0c4bcc24ea3a" />

### New task form:
<img width="387" height="327" alt="image" src="https://github.com/user-attachments/assets/17450d7b-4344-4831-8a28-2f854b41814e" />

### New task form (open):
<img width="400" height="505" alt="image" src="https://github.com/user-attachments/assets/03e531ce-f5c5-480a-abb0-d449dd122c4f" />

### Edit event form (the problematic one from #1363):
<img width="480" height="667" alt="image" src="https://github.com/user-attachments/assets/b20204d3-109b-433c-9986-5bf3a9b47a6c" />

---

- [X] I have read [CONTRIBUTING.md](https://github.com/gramps-project/gramps-web/blob/main/CONTRIBUTING.md)
- [X] This was discussed in an issue first, or it is small enough not to need one
- [X] I wrote this myself, or used an AI assistant and have reviewed every line
