### PR TITLE
Improve behaviour of chart hover previews

### DIFF
--- a/src/charts/FanChart.js
+++ b/src/charts/FanChart.js
@@ -389,6 +389,7 @@ export function FanChart(
             objectType: 'person',
             grampsId,
             anchorRect: this.getBoundingClientRect(),
+            chart: true,
           },
         })
       )
@@ -397,14 +398,6 @@ export function FanChart(
       if (window.matchMedia('(hover: none)').matches) return
       window.dispatchEvent(new CustomEvent('object:preview-hide'))
     })
-
-  cell
-    .append('title')
-    .text(d =>
-      nameDisplayFormat === chartNameDisplayFormat.surnameThenGiven
-        ? '' + d.data.name_surname + ', ' + d.data.name_given
-        : '' + d.data.name_given + ' ' + d.data.name_surname
-    )
 
   const fontSize = d => Math.min(12, (((d.y0 + d.y1) / 2) * (d.x1 - d.x0)) / 10)
 

--- a/src/charts/Timeline.js
+++ b/src/charts/Timeline.js
@@ -50,6 +50,7 @@ function attachPreviewHandlers(selection, getAnchorEl = el => el) {
             objectType: 'event',
             grampsId: d.gramps_id,
             anchorRect: getAnchorEl(this).getBoundingClientRect(),
+            chart: true,
           },
         })
       )

--- a/src/charts/personCard.js
+++ b/src/charts/personCard.js
@@ -158,6 +158,7 @@ export function setPersonCardInteraction(
         objectType: 'person',
         grampsId,
         anchorRect: this.getBoundingClientRect(),
+        chart: true,
       })
     })
     .on('mouseleave', () => {

--- a/src/components/GrampsjsObjectPreview.js
+++ b/src/components/GrampsjsObjectPreview.js
@@ -16,10 +16,14 @@ import './GrampsjsNote.js'
 import './GrampsjsMediaObject.js'
 
 const SHOW_DELAY = 200
+// In charts the pointer is almost always over some node, so previews there
+// wait longer to show only when the pointer rests on one node.
+const CHART_SHOW_DELAY = 500
 const HIDE_DELAY = 250
 const CACHE_MAX_SIZE = 50
 const POPUP_WIDTH = 580
 const POPUP_HEIGHT = 600
+const POPUP_MAX_VIEWPORT_FRACTION = 0.6
 const POPUP_MARGIN = 8
 
 // Some object types (e.g. events) typically have much less content than
@@ -31,8 +35,14 @@ const POPUP_HEIGHT_BY_TYPE = {
   repository: 500,
 }
 
+// Capped to a fraction of the viewport so that on small screens the popup
+// leaves most of the page visible.
 function getPopupHeight(objectType) {
-  return POPUP_HEIGHT_BY_TYPE[objectType] ?? POPUP_HEIGHT
+  const height = POPUP_HEIGHT_BY_TYPE[objectType] ?? POPUP_HEIGHT
+  return Math.min(
+    height,
+    Math.round(window.innerHeight * POPUP_MAX_VIEWPORT_FRACTION)
+  )
 }
 
 const NOTE_LINK_FORMAT = encodeURIComponent(
@@ -180,14 +190,28 @@ export class GrampsjsObjectPreview extends GrampsjsAppStateMixin(LitElement) {
 
   // Debounced: a burst of `object:preview-show` events (e.g. sweeping the
   // cursor across many chart nodes in quick succession) resolves to a
-  // single preview once the cursor settles on one target for SHOW_DELAY ms.
+  // single preview once the cursor settles on one target for SHOW_DELAY ms
+  // (CHART_SHOW_DELAY ms in charts).
   _handleShow(e) {
     const detail = e.detail
-    clearTimeout(this._hideTimer)
     clearTimeout(this._showTimer)
-    this._showTimer = setTimeout(() => {
-      this._showPreview(detail)
-    }, SHOW_DELAY)
+    // Returning to the anchor of the open popup keeps it open. When moving to
+    // a different object, the open popup still closes after HIDE_DELAY, so it
+    // does not linger over the chart while the new preview is pending.
+    if (
+      this._visible &&
+      detail.objectType === this._objectType &&
+      detail.grampsId === this._grampsId
+    ) {
+      clearTimeout(this._hideTimer)
+    }
+    this._showTimer = setTimeout(
+      () => {
+        clearTimeout(this._hideTimer)
+        this._showPreview(detail)
+      },
+      detail.chart ? CHART_SHOW_DELAY : SHOW_DELAY
+    )
   }
 
   _showPreview({objectType, grampsId, anchorRect}) {


### PR DESCRIPTION
This PR makes three changes to object previews (hover popups) in the chart views, see the related discussion in #1345:

- The delay from hover to popup is increased from 0.2 s (used for link previews) to 0.5 s in charts
- The popup height is capped on small screens
- The SVG title popup in the fan chart is removed as it duplicates the information in the object preview